### PR TITLE
Feat(#30):게시글 리스트,상세,댓글 스켈레톤 UI구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,10 +33,12 @@ export default function RootLayout({
       >
         <MSWProvider>
           <QueryProvider>
-            <LazyMotionProvider>
-              <Header />
-              {children}
-            </LazyMotionProvider>
+            <SelectProvider>
+              <LazyMotionProvider>
+                <Header />
+                {children}
+              </LazyMotionProvider>
+            </SelectProvider>
           </QueryProvider>
         </MSWProvider>
         <Toaster position="top-center" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,12 +33,10 @@ export default function RootLayout({
       >
         <MSWProvider>
           <QueryProvider>
-            <SelectProvider>
-              <LazyMotionProvider>
-                <Header />
-                {children}
-              </LazyMotionProvider>
-            </SelectProvider>
+            <LazyMotionProvider>
+              <Header />
+              {children}
+            </LazyMotionProvider>
           </QueryProvider>
         </MSWProvider>
         <Toaster position="top-center" />

--- a/src/components/post/Detail/Comment/index.tsx
+++ b/src/components/post/Detail/Comment/index.tsx
@@ -43,7 +43,6 @@ export default function Comment({
           }
         }}
       />
-
       <CommentList
         parents={parents}
         replies={replies}

--- a/src/components/post/Detail/PostDetail/index.tsx
+++ b/src/components/post/Detail/PostDetail/index.tsx
@@ -70,7 +70,8 @@ export default function PostDetail() {
       },
     ],
   }
-
+  //  const { data, isLoading } = usePostDetail(params.id)
+  //  if(isLoading ) <PostDetailSkeleton />
   return (
     <div className="min-h-screen bg-bg-base py-8 px-4 flex justify-center ">
       <div className="max-w-7xl w-full bg-bg-base rounded-lg p-8 border  border-[#DDDDDD]  ">

--- a/src/components/post/List/index.tsx
+++ b/src/components/post/List/index.tsx
@@ -93,7 +93,7 @@ export default function PostList() {
 
   // 나중에 API 연동 시 주석 해제
   // const [cursor, setCursor] = useState<string | undefined>(undefined)
-  // const { data } = usePosts({
+  // const { data,isLoading } = usePosts({
   //   lastPostId: cursor,
   //   size: 20,
   //   region: filters.region || undefined,
@@ -103,6 +103,7 @@ export default function PostList() {
   //   gender: filters.gender === '' ? undefined : filters.gender, // MALE | FEMALE | ALL
   //   keyword: filters.search || undefined,
   // })
+  // if(isLoading) return <PostListSkeleton/>
 
   return (
     <div>

--- a/src/components/post/Skeleton/CommentSkeleton/index.tsx
+++ b/src/components/post/Skeleton/CommentSkeleton/index.tsx
@@ -1,0 +1,39 @@
+export default function CommentItemSkeleton() {
+  return (
+    <div className="w-4xl mr-auto p-4">
+      <div className="bg-blue-50 rounded-lg p-4 animate-pulse">
+        <div className="h-4 w-28 bg-gray-200 rounded-md mb-3" />
+
+        <div className="w-full h-20 bg-gray-200 rounded-md" />
+
+        <div className="flex justify-end gap-2 mt-3">
+          <div className="w-16 h-8 bg-gray-200 rounded-md" />
+          <div className="w-16 h-8 bg-gray-200 rounded-md" />
+        </div>
+      </div>
+      <div className="flex gap-4 pt-8 animate-pulse">
+        <div className="w-12 h-12 rounded-full bg-gray-200" />
+
+        <div className="flex-1 space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="space-y-2">
+              <div className="h-4 w-24 bg-gray-200 rounded-md" />
+              <div className="h-3 w-20 bg-gray-200 rounded-md" />
+            </div>
+
+            <div className="w-4 h-4 bg-gray-200 rounded" />
+          </div>
+
+          <div className="space-y-2 mt-2">
+            <div className="h-4 w-2/3 bg-gray-200 rounded-md" />
+          </div>
+
+          <div className="flex gap-4 mt-2">
+            <div className="h-3 w-16 bg-gray-200 rounded-md" />
+            <div className="h-3 w-20 bg-gray-200 rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/post/Skeleton/PostCardSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostCardSkeleton/index.tsx
@@ -1,3 +1,37 @@
+'use client'
+
 export default function PostCardSkeleton() {
-  return <div>PostCardSkeleton</div>
+  return (
+    <div className="bg-white rounded-2xl p-6 shadow-sm border border-border animate-pulse">
+      <div className="flex gap-4">
+        <div className="w-[188px] h-[188px] rounded-2xl bg-bg-disabled" />
+        <div className="flex-1 ml-3">
+          <div className="flex gap-2 mb-2">
+            {[1, 2, 3].map((num) => (
+              <div key={num} className="h-6 w-12 bg-bg-disabled rounded-full" />
+            ))}
+          </div>
+
+          <div className="h-6 w-3/4 bg-bg-disabled rounded-md mb-2" />
+
+          <div className="flex gap-2 mb-3">
+            <div className="h-4 w-10 bg-bg-disabled rounded-md" />
+            <div className="h-4 w-16 bg-bg-disabled rounded-md" />
+          </div>
+
+          <div className="flex gap-2 flex-wrap mt-8">
+            {[1, 2, 3, 4].map((num) => (
+              <div key={num} className="h-4 w-20 bg-bg-disabled rounded-md" />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col items-end justify-between">
+          <div className="w-10 h-10 rounded-full bg-bg-disabled" />
+
+          <div className="w-24 h-8 bg-bg-disabled rounded-md" />
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/components/post/Skeleton/PostCardSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostCardSkeleton/index.tsx
@@ -1,0 +1,3 @@
+export default function PostCardSkeleton() {
+  return <div>PostCardSkeleton</div>
+}

--- a/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
@@ -1,0 +1,3 @@
+export default function PostDetailSkeleton() {
+  return <div>PostDetailSkeleton</div>
+}

--- a/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import CommentSkeleton from '../CommentSkeleton'
+
 export default function PostDetailSkeleton() {
   return (
     <div className="min-h-screen bg-bg-base py-8 px-4 flex justify-center">
@@ -60,6 +62,7 @@ export default function PostDetailSkeleton() {
           <div className="h-10 w-68 bg-bg-disabled rounded-md" />
           <div className="h-10 w-68 bg-bg-disabled rounded-md" />
         </div>
+        <CommentSkeleton />
       </div>
     </div>
   )

--- a/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
@@ -1,3 +1,66 @@
+'use client'
+
 export default function PostDetailSkeleton() {
-  return <div>PostDetailSkeleton</div>
+  return (
+    <div className="min-h-screen bg-bg-base py-8 px-4 flex justify-center">
+      <div className="max-w-7xl w-full bg-bg-base rounded-lg p-8 border border-[#DDDDDD] animate-pulse space-y-8">
+        {/* 제목 */}
+        <div className="space-y-3">
+          <div className="h-7 w-50 bg-bg-disabled rounded-md" />
+          <div className="flex gap-2"></div>
+        </div>
+        {/* 태그 */}
+        <div className="flex gap-3 mb-6">
+          {[1, 2, 3].map((num) => (
+            <div key={num} className="w-32 h-32 bg-bg-disabled rounded-xl" />
+          ))}
+        </div>
+        {/* 이미지 */}
+        <div className="h-4 w-20 bg-bg-disabled rounded-md" />
+        <div className="flex gap-2">
+          {[1, 2, 3].map((num) => (
+            <div key={num} className="h-6 w-14 bg-bg-disabled rounded-full" />
+          ))}
+        </div>
+        {/* 지역 */}
+        <div className="space-y-4">
+          <div className="h-4 w-30 bg-bg-disabled rounded-md" />
+          <div className="h-4 w-10 bg-bg-disabled rounded-md"></div>
+        </div>
+        {/* 일정 */}
+        <div>
+          <div className="h-4 w-30 bg-bg-disabled rounded-md mb-2" />
+          <div className="grid grid-cols-2 gap-4 w-2/3">
+            <div className="h-8 w-full bg-bg-disabled rounded-md" />
+            <div className="h-8 w-full bg-bg-disabled rounded-md" />
+          </div>
+        </div>
+        {/* 설명 */}
+        <div className="space-y-4">
+          <div className="h-4 w-30 bg-bg-disabled rounded-md" />
+          <div className="h-30 w-2/3 bg-bg-disabled rounded-md" />
+        </div>
+        {/* 인원 및 조건 */}
+        <div className="h-4 w-30 bg-bg-disabled rounded-md" />
+        <div className="h-4 w-70 bg-bg-disabled rounded-md" />
+        {/* 작성자 프로필 */}
+        <div className="h-6 w-36 bg-bg-disabled rounded-md" />
+        <div className="space-y-3 border p-6 rounded-2xl">
+          <div className="flex gap-4">
+            <div className="w-16 h-16 rounded-full bg-bg-disabled" />
+            <div className="space-y-2">
+              <div className="h-4 w-20 bg-bg-disabled rounded-md" />
+              <div className="h-4 w-28 bg-bg-disabled rounded-md" />
+              <div className="h-4 w-24 bg-bg-disabled rounded-md" />
+            </div>
+          </div>
+        </div>
+        {/* 버튼 */}
+        <div className="flex gap-3 items-center justify-center my-8">
+          <div className="h-10 w-68 bg-bg-disabled rounded-md" />
+          <div className="h-10 w-68 bg-bg-disabled rounded-md" />
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/components/post/Skeleton/PostListSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostListSkeleton/index.tsx
@@ -1,0 +1,3 @@
+export default function PostListSkeleton() {
+  return <div>PostListSkeleton</div>
+}

--- a/src/components/post/Skeleton/PostListSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostListSkeleton/index.tsx
@@ -1,3 +1,13 @@
+import PostCardSkeleton from '../PostCardSkeleton'
+
 export default function PostListSkeleton() {
-  return <div>PostListSkeleton</div>
+  return (
+    <div className="w-7xl mx-auto p-4">
+      <div className="space-y-4">
+        {[1, 2, 3].map((num) => (
+          <PostCardSkeleton key={num} />
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/src/components/post/Skeleton/index.ts
+++ b/src/components/post/Skeleton/index.ts
@@ -1,0 +1,3 @@
+export { default as PostListSkeleton } from './PostListSkeleton'
+export { default as PostCardSkeleton } from './PostCardSkeleton'
+export { default as PostDetailSkeleton } from './PostDetailSkeleton'


### PR DESCRIPTION
## 📌 이슈 넘버
> close #30 

## 📄 작업 페이지 및 내용 요약
> 데이터 fetch 동안 콘텐츠 레이아웃이 유지되도록 하여 화면 깜빡임과 사용자 혼란을 줄였습니다.

## 📝 작업 내용
> - PostList 화면에 Skeleton 리스트 컴포넌트 적용
> - PostDetail 화면 로딩 시 Skeleton 적용
> - 댓글 목록 렌더 전 CommentSkeleton 보여주도록 처리

