### PR TITLE
Refactor(#36): Post 관련 페이지 생성된 shadcn UI 컴포넌트로 교체

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,7 @@
   --color-main: #498cf8; /* Main Color */
   --color-main-from: #498cf8; /* Gradient from */
   --color-main-to: #003c9d; /* Gradient to */
+  --color-sub: #edf4fb; /* Sub Color */
 
   --color-bg-base: #fafafa; /* Background */
   --color-bg-input: #f9fafb; /* Input Field */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import './globals.css'
 import { SessionProvider } from 'next-auth/react'
 
 import { Header } from '@/components/common'
-import { SelectProvider } from '@/components/common/Select/select.context'
 import { Toaster } from '@/components/ui'
 import { LazyMotionProvider, MSWProvider, QueryProvider } from '@/providers'
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import { PostList } from '@/components/post'
+import { PostForm, PostList } from '@/components/post'
 
 export default function Home() {
-  return <PostList />
+  return <PostForm />
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
-import { PostForm, PostList } from '@/components/post'
+import { PostDetail, PostForm, PostList } from '@/components/post'
 
 export default function Home() {
-  return <PostForm />
+  return (
+    <div>
+      <PostForm />
+      {/* <PostList /> */}
+      {/* <PostDetail /> */}
+    </div>
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
-import { PostForm, PostList } from '@/components/post'
+import { PostList } from '@/components/post'
 
 export default function Home() {
-  return <PostForm />
+  return <PostList />
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,9 @@
-import { PostDetail, PostForm, PostList } from '@/components/post'
+import { PostList } from '@/components/post'
 
 export default function Home() {
   return (
     <div>
-      <PostForm />
-      {/* <PostList /> */}
-      {/* <PostDetail /> */}
+      <PostList />
     </div>
   )
 }

--- a/src/components/common/Skeleton/index.tsx
+++ b/src/components/common/Skeleton/index.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import { forwardRef, type ComponentProps } from 'react'
+
+import { cn } from '@/lib/common'
+
+const skeletonVariants = cva('animate-pulse bg-bg-disabled rounded-xl', {
+  variants: {
+    variant: {
+      default: 'bg-sub ',
+    },
+    size: {
+      sm: 'h-4 w-20 rounded-md',
+      md: 'h-6 w-40 rounded-lg',
+      lg: 'h-8 w-full rounded-2xl',
+      circle: 'w-10 h-10 rounded-full',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'md',
+  },
+})
+
+export const Skeleton = forwardRef<
+  HTMLDivElement,
+  ComponentProps<'div'> & VariantProps<typeof skeletonVariants>
+>(({ className, variant, size, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-slot="skeleton"
+      className={cn(skeletonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+})
+
+Skeleton.displayName = 'Skeleton'
+
+export { skeletonVariants }

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,5 +1,6 @@
 export * from './Button'
 export * from './Input'
+export * from './Skeleton'
 export { default as Header } from './Header'
 export { default as Label } from './Label'
 export { default as Select } from './Select'

--- a/src/components/post/Detail/Comment/CommentInput/index.tsx
+++ b/src/components/post/Detail/Comment/CommentInput/index.tsx
@@ -37,7 +37,6 @@ export default function CommentInput({
         onChange={(e) => setText(e.target.value)}
         placeholder="댓글을 남겨보세요."
         rows={3}
-        className="bg-bg-input"
       />
 
       <div className="flex justify-end gap-2 mt-3">

--- a/src/components/post/Detail/Comment/CommentInput/index.tsx
+++ b/src/components/post/Detail/Comment/CommentInput/index.tsx
@@ -20,14 +20,15 @@ export default function CommentInput({
 }: CommentInputProps) {
   const [text, setText] = useState('')
 
-  const handleSubmit = () => {
+  const handleSubmit = (e?: React.FormEvent) => {
+    if (e) e.preventDefault()
     if (!text.trim()) return
     onSubmit(text.trim(), parentId)
     setText('')
   }
 
   return (
-    <div className="bg-blue-50 rounded-lg p-4">
+    <form className="bg-blue-50 rounded-lg p-4" onSubmit={handleSubmit}>
       <p className="text-sm text-gray-900 mb-3">
         <span className="font-semibold">{nickname}</span>
       </p>
@@ -40,14 +41,19 @@ export default function CommentInput({
       />
 
       <div className="flex justify-end gap-2 mt-3">
-        <Button variant="secondary" className="h-8" onClick={onCancel}>
+        <Button
+          variant="secondary"
+          className="h-8"
+          onClick={onCancel}
+          type="button"
+        >
           취소
         </Button>
 
-        <Button className="h-8" onClick={handleSubmit}>
+        <Button className="h-8" type="submit">
           등록
         </Button>
       </div>
-    </div>
+    </form>
   )
 }

--- a/src/components/post/Detail/Comment/CommentInput/index.tsx
+++ b/src/components/post/Detail/Comment/CommentInput/index.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 
 import { Button } from '@/components/common'
+import { Textarea } from '@/components/ui'
 
 interface CommentInputProps {
   nickname: string
@@ -31,12 +32,12 @@ export default function CommentInput({
         <span className="font-semibold">{nickname}</span>
       </p>
 
-      <textarea
+      <Textarea
         value={text}
         onChange={(e) => setText(e.target.value)}
         placeholder="댓글을 남겨보세요."
         rows={3}
-        className="w-full border rounded-lg px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 outline-none resize-none"
+        className="bg-bg-input"
       />
 
       <div className="flex justify-end gap-2 mt-3">

--- a/src/components/post/Detail/PostDetail/PostInfo/index.tsx
+++ b/src/components/post/Detail/PostDetail/PostInfo/index.tsx
@@ -1,3 +1,5 @@
+import { CalendarDays } from 'lucide-react'
+
 interface Props {
   region: string
   period: {
@@ -11,7 +13,6 @@ interface Props {
   }
   conditions: {
     ageCondition: string
-    birthYear: number
     genderCondition: string
   }
 }
@@ -38,13 +39,15 @@ export default function PostInfo({
         </h3>
         <div className="grid grid-cols-2 gap-4 w-2/3">
           <div>
-            <div className="px-4 py-2 bg-blue-50 rounded-md text-sm text-text-input">
+            <div className="px-4 py-2 bg-blue-50 rounded-md text-sm text-text-input flex gap-2">
+              <CalendarDays className="text-main size-5" />
               {period.startDate}
             </div>
           </div>
 
           <div>
-            <div className="px-4 py-2 bg-blue-50 rounded-md text-sm text-text-input">
+            <div className="px-4 py-2 bg-blue-50 rounded-md text-sm text-text-input flex gap-2">
+              <CalendarDays className="text-main size-5" />
               {period.endDate}
             </div>
           </div>
@@ -68,7 +71,6 @@ export default function PostInfo({
             총 <span className="text-main">{stats.maxMembers}</span>명
           </span>
           <span>
-            <span className="text-main">{conditions.birthYear}</span>년생{' '}
             <span className="text-main">{conditions.ageCondition}</span>
           </span>
           <span className="text-main">{conditions.genderCondition}</span>

--- a/src/components/post/Detail/PostDetail/PostInfo/index.tsx
+++ b/src/components/post/Detail/PostDetail/PostInfo/index.tsx
@@ -1,6 +1,7 @@
 import { CalendarDays } from 'lucide-react'
 
 interface Props {
+  nation: string
   region: string
   period: {
     startDate: string
@@ -17,7 +18,12 @@ interface Props {
   }
 }
 
+const SECTION_TITLE_STYLE = 'font-semibold mb-2 text-text-base text-lg'
+const BLUE_BOX_STYLE = 'px-4 py-2 bg-blue-50 rounded-md text-sm text-text-input'
+const TEXT_STYLE = 'text-sm text-text-input'
+
 export default function PostInfo({
+  nation,
   region,
   period,
   content,
@@ -27,52 +33,37 @@ export default function PostInfo({
   return (
     <div className="space-y-8">
       <div>
-        <h3 className=" font-semibold mb-2 text-text-base text-lg">
-          여행 지역
-        </h3>
-        <p className="text-sm text-text-input">{region}</p>
+        <h3 className={SECTION_TITLE_STYLE}>여행 지역</h3>
+        <span className={`${TEXT_STYLE} mr-1`}>{nation}</span>
+        <span className={TEXT_STYLE}>{region}</span>
       </div>
 
       <div>
-        <h3 className=" font-semibold mb-2 text-text-base text-lg">
-          여행 일정
-        </h3>
+        <h3 className={SECTION_TITLE_STYLE}>여행 일정</h3>
         <div className="grid grid-cols-2 gap-4 w-2/3">
-          <div>
-            <div className="px-4 py-2 bg-blue-50 rounded-md text-sm text-text-input flex gap-2">
-              <CalendarDays className="text-main size-5" />
-              {period.startDate}
-            </div>
+          <div className={`${BLUE_BOX_STYLE} flex gap-2`}>
+            <CalendarDays className="text-main size-5" />
+            {period.startDate}
           </div>
-
-          <div>
-            <div className="px-4 py-2 bg-blue-50 rounded-md text-sm text-text-input flex gap-2">
-              <CalendarDays className="text-main size-5" />
-              {period.endDate}
-            </div>
+          <div className={`${BLUE_BOX_STYLE} flex gap-2`}>
+            <CalendarDays className="text-main size-5" />
+            {period.endDate}
           </div>
         </div>
       </div>
 
       <div>
-        <h3 className=" font-semibold mb-2 text-text-base text-lg">
-          모집 설명
-        </h3>
-        <div className="px-4 py-4 bg-blue-50 rounded-lg text-sm text-text-input w-2/3">
-          {content}
-        </div>
+        <h3 className={SECTION_TITLE_STYLE}>모집 설명</h3>
+        <div className={`${BLUE_BOX_STYLE} rounded-lg w-2/3`}>{content}</div>
       </div>
 
-      <div className="font-semibold">
-        <h3 className="  mb-4 text-text-base text-lg">모집 정원 및 조건</h3>
-
-        <div className="flex gap-4 ">
+      <div>
+        <h3 className={SECTION_TITLE_STYLE}>모집 정원 및 조건</h3>
+        <div className="flex gap-4">
           <span>
             총 <span className="text-main">{stats.maxMembers}</span>명
           </span>
-          <span>
-            <span className="text-main">{conditions.ageCondition}</span>
-          </span>
+          <span className="text-main">{conditions.ageCondition}</span>
           <span className="text-main">{conditions.genderCondition}</span>
         </div>
       </div>

--- a/src/components/post/Detail/PostDetail/PostWriter/index.tsx
+++ b/src/components/post/Detail/PostDetail/PostWriter/index.tsx
@@ -10,6 +10,10 @@ interface Props {
   }
 }
 
+const LABEL_STYLE = 'text-text-disabled w-20'
+const VALUE_STYLE = 'text-text-base'
+const ROW_STYLE = 'flex gap-3'
+
 export default function PostWriter({ writer }: Props) {
   const {
     nickname,
@@ -26,47 +30,47 @@ export default function PostWriter({ writer }: Props) {
       <h3 className="text-lg font-semibold mb-3 text-text-base">
         작성자 프로필
       </h3>
+
       <div className="flex items-center justify-between p-4 border-2 border-gray-200 rounded-2xl">
         <div className="flex gap-4">
           <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center shrink-0" />
 
-          <div className="flex  gap-20 mt-1">
+          <div className="flex gap-20 mt-1">
             <span className="font-semibold text-text-base text-lg">
               {nickname}
             </span>
 
             <div className="flex gap-20 text-sm">
               <div className="flex-col gap-2">
-                <div className="flex gap-3">
-                  <span className="text-text-disabled w-20">나이</span>
-                  <span className="text-text-base">
+                <div className={ROW_STYLE}>
+                  <span className={LABEL_STYLE}>나이</span>
+                  <span className={VALUE_STYLE}>
                     {birth}년생 / {age}살
                   </span>
                 </div>
 
-                <div className="flex gap-3">
-                  <span className="text-text-disabled w-20">성별</span>
-                  <span className="text-text-base">
+                <div className={ROW_STYLE}>
+                  <span className={LABEL_STYLE}>성별</span>
+                  <span className={VALUE_STYLE}>
                     {gender === 'MALE' ? '남성' : '여성'}
                   </span>
                 </div>
 
-                <div className="flex gap-3">
-                  <span className="text-text-disabled w-20">MBTI</span>
-                  <span className="text-text-base">{mbti}</span>
+                <div className={ROW_STYLE}>
+                  <span className={LABEL_STYLE}>MBTI</span>
+                  <span className={VALUE_STYLE}>{mbti}</span>
                 </div>
               </div>
+
               <div>
-                <div className="flex gap-3">
-                  <span className="text-text-disabled w-20">여행 스타일</span>
-                  <span className="text-text-base">{tripstyle}</span>
+                <div className={ROW_STYLE}>
+                  <span className={LABEL_STYLE}>여행 스타일</span>
+                  <span className={VALUE_STYLE}>{tripstyle}</span>
                 </div>
 
-                <div className="flex gap-3">
-                  <span className="text-text-disabled w-20">숙소 취향</span>
-                  <span className="text-text-base">
-                    {accommodationPreference}
-                  </span>
+                <div className={ROW_STYLE}>
+                  <span className={LABEL_STYLE}>숙소 취향</span>
+                  <span className={VALUE_STYLE}>{accommodationPreference}</span>
                 </div>
               </div>
             </div>

--- a/src/components/post/Detail/PostDetail/index.tsx
+++ b/src/components/post/Detail/PostDetail/index.tsx
@@ -12,6 +12,7 @@ import PostWriter from './PostWriter'
 export default function PostDetail() {
   // 임시 데이터
   const postDetail = {
+    postId: 'post-2',
     title: '카지노 가보실 분',
     region: '미국',
     period: {

--- a/src/components/post/Detail/PostDetail/index.tsx
+++ b/src/components/post/Detail/PostDetail/index.tsx
@@ -14,7 +14,8 @@ export default function PostDetail() {
   const postDetail = {
     postId: 'post-2',
     title: '카지노 가보실 분',
-    region: '미국',
+    nation: '미국',
+    region: '뉴욕',
     period: {
       startDate: '2025-02-10',
       endDate: '2025-02-20 ',
@@ -89,6 +90,7 @@ export default function PostDetail() {
         <PostTags tags={postDetail.tags} />
 
         <PostInfo
+          nation={postDetail.nation}
           region={postDetail.region}
           period={{
             startDate: postDetail.period.startDate,

--- a/src/components/post/Detail/PostDetail/index.tsx
+++ b/src/components/post/Detail/PostDetail/index.tsx
@@ -15,21 +15,21 @@ export default function PostDetail() {
     title: '카지노 가보실 분',
     region: '미국',
     period: {
-      startDate: '2025-02-10 09:00 AM',
-      endDate: '2025-02-20 06:00 PM',
+      startDate: '2025-02-10',
+      endDate: '2025-02-20 ',
     },
     stats: {
       maxMembers: 3,
       currentMembers: 0,
       viewCount: 5,
     },
-    content: '함께 여행할 분을 찾습니다!',
+    content:
+      '함께 여행할 분을 찾습니다!함께 여행할 분을 찾습니다!함께 여행할 분을 찾습니다!함께 여행할 분을 찾습니다!함께 여행할 분을 찾습니다!함께 여행할 분을 찾습니다!함께 여행할 분을 찾습니다!함께 여행할 분을 찾습니다!',
     createdAt: '2025-12-06T16:19:42.712967883',
     tags: ['힐링', '도박', '카지노'],
     conditions: {
-      ageCondition: '이상',
-      birthYear: 1995,
-      genderCondition: '모두',
+      ageCondition: '20대만',
+      genderCondition: '남자만',
     },
     isBookmarked: false,
     commentCount: 22,
@@ -100,7 +100,6 @@ export default function PostDetail() {
           }}
           conditions={{
             ageCondition: postDetail.conditions.ageCondition,
-            birthYear: postDetail.conditions.birthYear,
             genderCondition: postDetail.conditions.genderCondition,
           }}
         />

--- a/src/components/post/Form/Date/index.tsx
+++ b/src/components/post/Form/Date/index.tsx
@@ -4,6 +4,8 @@ import { Calendar } from 'lucide-react'
 import { useRef } from 'react'
 import DatePicker from 'react-datepicker'
 
+import { Label } from '@/components/ui'
+
 interface DateProps {
   startDate: Date | null
   endDate: Date | null
@@ -24,9 +26,9 @@ export default function Date({
     <div className="flex justify-between mb-2 gap-8">
       {/* 시작 날짜 */}
       <div className="flex flex-col relative">
-        <label className="text-sm text-text-base mb-2">
+        <Label className=" mb-2">
           여행 시작 일시 <span className="text-danger">*</span>
-        </label>
+        </Label>
 
         <div className="relative">
           <DatePicker
@@ -47,9 +49,9 @@ export default function Date({
 
       {/* 종료 날짜 */}
       <div className="flex flex-col relative">
-        <label className="text-sm text-text-base mb-2">
+        <Label className=" mb-2">
           여행 종료 일시 <span className="text-danger">*</span>
-        </label>
+        </Label>
 
         <div className="relative">
           <DatePicker

--- a/src/components/post/Form/Date/index.tsx
+++ b/src/components/post/Form/Date/index.tsx
@@ -29,7 +29,7 @@ export default function Date({
           여행 시작 일시 <span className="text-danger">*</span>
         </Label>
 
-        <div className="relative flex items-center gap-2 px-4 py-2.5 w-full bg-[#EDF4FB] rounded-lg text-sm  cursor-pointer">
+        <div className="relative flex items-center gap-2 px-4 py-2.5 w-full bg-sub rounded-lg text-sm  cursor-pointer">
           <DatePicker
             ref={startRef}
             selected={startDate}
@@ -51,7 +51,7 @@ export default function Date({
           여행 종료 일시 <span className="text-danger">*</span>
         </Label>
 
-        <div className="relative flex items-center gap-2 px-4 py-2.5 w-full bg-[#EDF4FB] rounded-lg text-sm  cursor-pointer">
+        <div className="relative flex items-center gap-2 px-4 py-2.5 w-full bg-sub rounded-lg text-sm  cursor-pointer">
           <DatePicker
             ref={endRef}
             selected={endDate}

--- a/src/components/post/Form/Date/index.tsx
+++ b/src/components/post/Form/Date/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Calendar } from 'lucide-react'
+import { CalendarDays } from 'lucide-react'
 import { useRef } from 'react'
 import DatePicker from 'react-datepicker'
 
@@ -39,7 +39,7 @@ export default function Date({
             placeholderText="시작 날짜 선택"
           />
 
-          <Calendar
+          <CalendarDays
             className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-main size-5"
             onClick={() => startRef.current?.setOpen(true)}
           />
@@ -61,7 +61,7 @@ export default function Date({
             placeholderText="종료 날짜 선택"
           />
 
-          <Calendar
+          <CalendarDays
             className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-main size-5"
             onClick={() => endRef.current?.setOpen(true)}
           />

--- a/src/components/post/Form/Date/index.tsx
+++ b/src/components/post/Form/Date/index.tsx
@@ -23,21 +23,20 @@ export default function Date({
   const endRef = useRef<DatePicker | null>(null)
 
   return (
-    <div className="flex justify-between mb-2 gap-8">
-      {/* 시작 날짜 */}
+    <div className="flex gap-8">
       <div className="flex flex-col relative">
-        <Label className=" mb-2">
+        <Label className=" mb-3">
           여행 시작 일시 <span className="text-danger">*</span>
         </Label>
 
-        <div className="relative">
+        <div className="relative flex items-center gap-2 px-4 py-2.5 w-full bg-[#EDF4FB] rounded-lg text-sm  cursor-pointer">
           <DatePicker
             ref={startRef}
             selected={startDate}
             onChange={(d) => onChangeStartDate(d)}
             dateFormat="yyyy-MM-dd"
-            className="px-4 py-2.5 rounded-lg text-sm bg-[#EDF4FB] outline-none w-[200px]"
-            placeholderText="날짜 선택"
+            className="text-muted-foreground font-medium text-base bg-sub"
+            placeholderText="시작 날짜 선택"
           />
 
           <Calendar
@@ -47,20 +46,19 @@ export default function Date({
         </div>
       </div>
 
-      {/* 종료 날짜 */}
       <div className="flex flex-col relative">
-        <Label className=" mb-2">
+        <Label className=" mb-3">
           여행 종료 일시 <span className="text-danger">*</span>
         </Label>
 
-        <div className="relative">
+        <div className="relative flex items-center gap-2 px-4 py-2.5 w-full bg-[#EDF4FB] rounded-lg text-sm  cursor-pointer">
           <DatePicker
             ref={endRef}
             selected={endDate}
             onChange={(d) => onChangeEndDate(d)}
             dateFormat="yyyy-MM-dd"
-            className="px-4 py-2.5 rounded-lg text-sm bg-[#EDF4FB] outline-none w-[200px]"
-            placeholderText="날짜 선택"
+            className="text-muted-foreground font-medium text-base bg-sub"
+            placeholderText="종료 날짜 선택"
           />
 
           <Calendar

--- a/src/components/post/Form/Description/index.tsx
+++ b/src/components/post/Form/Description/index.tsx
@@ -1,3 +1,5 @@
+import { Label, Textarea } from '@/components/ui'
+
 interface DescriptionProps {
   description: string
   onChangeDescription: (v: string) => void
@@ -9,15 +11,12 @@ export default function Description({
 }: DescriptionProps) {
   return (
     <div>
-      <label className="block text-sm text-text-base mb-2">
-        모집 설명 (0/500)
-      </label>
-      <textarea
+      <Label className="mb-2">모집 설명</Label>
+      <Textarea
         value={description}
         onChange={(e) => onChangeDescription(e.target.value)}
         rows={4}
         placeholder="모집 설명을 입력해주세요"
-        className="w-full px-4 py-2.5 rounded-lg text-sm resize-none bg-[#EDF4FB] outline-none placeholder:text-text-input"
       />
     </div>
   )

--- a/src/components/post/Form/Header/index.tsx
+++ b/src/components/post/Form/Header/index.tsx
@@ -1,8 +1,13 @@
+import { X } from 'lucide-react'
+import { useState } from 'react'
+
+import { Input, Label } from '@/components/ui'
+
 interface HeaderProps {
   title: string
   tags: string[]
   onChangeTitle: (v: string) => void
-  onChangeTags: (v: string) => void
+  onChangeTags: (v: string[]) => void
 }
 
 export default function Header({
@@ -11,32 +16,67 @@ export default function Header({
   onChangeTitle,
   onChangeTags,
 }: HeaderProps) {
+  const [tagInput, setTagInput] = useState('')
+
+  const addTag = () => {
+    const newTag = tagInput.trim()
+    if (!newTag) return
+    if (tags.includes(newTag)) return
+    if (tags.length >= 5) return
+
+    onChangeTags([...tags, newTag])
+    setTagInput('')
+  }
+
   return (
     <>
       <div>
-        <label className="block text-sm text-text-base mb-2">
+        <Label className="mb-2">
           모임 이름 <span className="text-danger">*</span>
-        </label>
-        <input
+        </Label>
+        <Input
           value={title}
           onChange={(e) => onChangeTitle(e.target.value)}
-          type="text"
           placeholder="모임 이름을 작성해주세요"
-          className="w-full px-4 py-2.5 rounded-lg text-sm bg-[#EDF4FB] placeholder:text-text-input outline-none"
         />
       </div>
 
       <div>
-        <label className="block text-sm text-text-base mb-2">
+        <Label className="mb-2">
           여행 태그 <span className="text-danger">*</span>
-        </label>
-        <input
-          value={tags.join(', ')}
-          onChange={(e) => onChangeTags(e.target.value)}
-          type="text"
-          placeholder="태그로 선택해주세요, 최대 5개"
-          className="w-full px-4 py-2.5 rounded-lg text-sm bg-[#EDF4FB] placeholder:text-text-input outline-none"
+        </Label>
+
+        <Input
+          value={tagInput}
+          placeholder="여행 테마를 작성해주세요. 최대 5개"
+          onChange={(e) => setTagInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              addTag()
+            }
+          }}
         />
+
+        <div className="flex flex-wrap gap-2 mt-3">
+          {tags.map((tag, index) => (
+            <div
+              key={index}
+              className="flex items-center gap-1 px-2 py-1 border border-main text-main rounded-full text-sm bg-sub"
+            >
+              <span>#{tag}</span>
+              <button
+                type="button"
+                onClick={() => onChangeTags(tags.filter((_, i) => i !== index))}
+                className="text-main hover:text-danger"
+              >
+                <div className="border border-main rounded-full">
+                  <X className="size-3" />
+                </div>
+              </button>
+            </div>
+          ))}
+        </div>
       </div>
     </>
   )

--- a/src/components/post/Form/Header/index.tsx
+++ b/src/components/post/Form/Header/index.tsx
@@ -58,11 +58,11 @@ export default function Header({
           }}
         />
 
-        <div className="flex flex-wrap gap-2 mt-3">
+        <div className="flex flex-wrap gap-2 ">
           {tags.map((tag, index) => (
             <div
               key={index}
-              className="flex items-center gap-1 px-2 py-1 border border-main text-main rounded-full text-sm bg-sub"
+              className="flex items-center gap-1 px-2 py-1 border border-main text-main rounded-full text-sm bg-sub mt-3"
             >
               <span>#{tag}</span>
               <button

--- a/src/components/post/Form/Header/index.tsx
+++ b/src/components/post/Form/Header/index.tsx
@@ -59,15 +59,15 @@ export default function Header({
         />
 
         <div className="flex flex-wrap gap-2 ">
-          {tags.map((tag, index) => (
+          {tags.map((tag) => (
             <div
-              key={index}
+              key={tag}
               className="flex items-center gap-1 px-2 py-1 border border-main text-main rounded-full text-sm bg-sub mt-3"
             >
               <span>#{tag}</span>
               <button
                 type="button"
-                onClick={() => onChangeTags(tags.filter((_, i) => i !== index))}
+                onClick={() => onChangeTags(tags)}
                 className="text-main hover:text-danger"
               >
                 <div className="border border-main rounded-full ">

--- a/src/components/post/Form/Header/index.tsx
+++ b/src/components/post/Form/Header/index.tsx
@@ -31,7 +31,7 @@ export default function Header({
   return (
     <>
       <div>
-        <Label className="mb-2">
+        <Label className="mb-3">
           모임 이름 <span className="text-danger">*</span>
         </Label>
         <Input
@@ -42,7 +42,7 @@ export default function Header({
       </div>
 
       <div>
-        <Label className="mb-2">
+        <Label className="mb-3">
           여행 태그 <span className="text-danger">*</span>
         </Label>
 
@@ -58,7 +58,7 @@ export default function Header({
           }}
         />
 
-        <div className="flex flex-wrap gap-2 mt-3">
+        <div className="flex flex-wrap gap-2">
           {tags.map((tag, index) => (
             <div
               key={index}
@@ -70,7 +70,7 @@ export default function Header({
                 onClick={() => onChangeTags(tags.filter((_, i) => i !== index))}
                 className="text-main hover:text-danger"
               >
-                <div className="border border-main rounded-full">
+                <div className="border border-main rounded-full ">
                   <X className="size-3" />
                 </div>
               </button>

--- a/src/components/post/Form/Header/index.tsx
+++ b/src/components/post/Form/Header/index.tsx
@@ -58,7 +58,7 @@ export default function Header({
           }}
         />
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 mt-3">
           {tags.map((tag, index) => (
             <div
               key={index}

--- a/src/components/post/Form/ImageUpload/index.tsx
+++ b/src/components/post/Form/ImageUpload/index.tsx
@@ -1,6 +1,9 @@
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 
+import { Button } from '@/components/common'
+import { Label } from '@/components/ui'
+
 export default function ImageUpload() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [previews, setPreviews] = useState<string[]>([])
@@ -27,9 +30,9 @@ export default function ImageUpload() {
   }, [previews])
   return (
     <div>
-      <label className="block text-sm text-text-base mb-3">
+      <Label className=" mb-2">
         이미지 <span className="text-danger">*</span>
-      </label>
+      </Label>
 
       <div className="flex justify-between gap-2 ">
         <div
@@ -56,12 +59,9 @@ export default function ImageUpload() {
           )}
         </div>
 
-        <button
-          onClick={openPicker}
-          className=" p-2.5 w-25 border border-main text-main rounded-lg text-sm hover:bg-blue-50"
-        >
+        <Button onClick={openPicker} variant="secondary">
           파일 찾기
-        </button>
+        </Button>
 
         <input
           ref={fileInputRef}

--- a/src/components/post/Form/ImageUpload/index.tsx
+++ b/src/components/post/Form/ImageUpload/index.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { X } from 'lucide-react'
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
 
@@ -14,46 +17,70 @@ export default function ImageUpload() {
     const files = e.target.files
     if (!files) return
 
-    const newUrls = [...previews]
+    const newUrls: string[] = []
 
     Array.from(files).forEach((file) => {
-      if (newUrls.length >= 3) return
-      newUrls.push(URL.createObjectURL(file))
+      if (previews.length + newUrls.length < 3) {
+        newUrls.push(URL.createObjectURL(file))
+      }
     })
 
-    setPreviews(newUrls)
+    setPreviews((prev) => [...prev, ...newUrls])
+
+    e.target.value = ''
   }
+
+  const removeImage = (idx: number) => {
+    const next = [...previews]
+    URL.revokeObjectURL(next[idx])
+    next.splice(idx, 1)
+    setPreviews(next)
+  }
+
   useEffect(() => {
     return () => {
       previews.forEach((url) => URL.revokeObjectURL(url))
     }
   }, [previews])
+
   return (
     <div>
-      <Label className=" mb-2">
+      <Label className="mb-2">
         이미지 <span className="text-danger">*</span>
       </Label>
 
-      <div className="flex justify-between gap-2 ">
+      <div className="flex gap-2">
         <div
           onClick={openPicker}
-          className="flex items-center px-4 py-2.5 w-full bg-[#EDF4FB] rounded-lg text-sm text-text-input cursor-pointer overflow-hidden "
+          className="flex items-center gap-2 px-4 py-2.5 w-full bg-[#EDF4FB] rounded-lg text-sm  cursor-pointer"
         >
           {previews.length === 0 ? (
-            <span className="text-text-input leading-6">
+            <span className="text-muted-foreground font-medium text-base">
               최대 3장, 5MB 제한
             </span>
           ) : (
             <div className="flex gap-2">
-              {previews.map((src) => (
-                <Image
-                  key={src}
-                  src={src}
-                  alt="preview"
-                  width={40}
-                  height={40}
-                  className="rounded-md object-cover"
-                />
+              {previews.map((src, idx) => (
+                <div key={src} className="relative">
+                  <Image
+                    src={src}
+                    alt="preview"
+                    width={48}
+                    height={48}
+                    className="rounded-md object-cover"
+                  />
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      removeImage(idx)
+                    }}
+                    className="absolute -top-1 -right-1 bg-black/50 text-white size-4 text-xs rounded-full flex items-center justify-center"
+                  >
+                    <div className="border border-main rounded-full ">
+                      <X className="size-3" />
+                    </div>
+                  </button>
+                </div>
               ))}
             </div>
           )}

--- a/src/components/post/Form/ImageUpload/index.tsx
+++ b/src/components/post/Form/ImageUpload/index.tsx
@@ -52,7 +52,7 @@ export default function ImageUpload() {
       <div className="flex gap-2">
         <div
           onClick={openPicker}
-          className="flex items-center gap-2 px-4 py-2.5 w-full bg-[#EDF4FB] rounded-lg text-sm  cursor-pointer"
+          className="flex items-center gap-2 px-4 py-2.5 w-full bg-sub rounded-lg text-sm  cursor-pointer"
         >
           {previews.length === 0 ? (
             <span className="text-muted-foreground font-medium text-base">

--- a/src/components/post/Form/Info/index.tsx
+++ b/src/components/post/Form/Info/index.tsx
@@ -38,7 +38,7 @@ export default function Info({
 }: InfoProps) {
   return (
     <>
-      <div className="flex">
+      <div className="flex gap-4">
         <div className="w-1/2">
           <Label className=" mb-3">
             국가 <span className="text-danger">*</span>
@@ -46,7 +46,7 @@ export default function Info({
 
           <div className="relative">
             <Select value={region} onValueChange={onChangeRegion}>
-              <SelectTrigger>
+              <SelectTrigger className=" w-full">
                 <SelectValue placeholder="국가를 선택해주세요" />
               </SelectTrigger>
               <SelectContent>
@@ -67,7 +67,7 @@ export default function Info({
           </Label>
           <div className="relative">
             <Select value={city} onValueChange={onChangeCity}>
-              <SelectTrigger>
+              <SelectTrigger className=" w-full">
                 <SelectValue placeholder="도시를 선택해주세요" />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/post/Form/Info/index.tsx
+++ b/src/components/post/Form/Info/index.tsx
@@ -13,17 +13,20 @@ import { AGE_OPTIONS, GENDER_OPTIONS, REGION_OPTIONS } from '@/constants/posts'
 
 interface InfoProps {
   region: string
+  city: string
   member: string
   age: string
   gender: string
   onChangeMember: (v: string) => void
   onChangeRegion: (v: string) => void
+  onChangeCity: (v: string) => void
   onChangeAge: (v: string) => void
   onChangeGender: (v: string) => void
 }
 
 export default function Info({
   region,
+  city,
   member,
   age,
   gender,
@@ -31,9 +34,55 @@ export default function Info({
   onChangeRegion,
   onChangeAge,
   onChangeGender,
+  onChangeCity,
 }: InfoProps) {
   return (
     <>
+      <div className="flex">
+        <div className="w-1/2">
+          <Label className=" mb-3">
+            국가 <span className="text-danger">*</span>
+          </Label>
+
+          <div className="relative">
+            <Select value={region} onValueChange={onChangeRegion}>
+              <SelectTrigger>
+                <SelectValue placeholder="국가를 선택해주세요" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {REGION_OPTIONS.map((location) => (
+                    <SelectItem key={location} value={location}>
+                      {location}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div className="w-1/2">
+          <Label className=" mb-3">
+            도시 <span className="text-danger">*</span>
+          </Label>
+          <div className="relative">
+            <Select value={city} onValueChange={onChangeCity}>
+              <SelectTrigger>
+                <SelectValue placeholder="도시를 선택해주세요" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {REGION_OPTIONS.map((location) => (
+                    <SelectItem key={location} value={location}>
+                      {location}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </div>
       <div>
         <Label className="mb-3">
           모집 정원 <span className="text-danger">*</span>
@@ -65,29 +114,6 @@ export default function Info({
         </div>
       </div>
       <div className="flex items-center justify-between">
-        <div>
-          <Label className=" mb-3">
-            국가 <span className="text-danger">*</span>
-          </Label>
-
-          <div className="relative">
-            <Select value={region} onValueChange={onChangeRegion}>
-              <SelectTrigger>
-                <SelectValue placeholder="국가를 선택해주세요" />
-              </SelectTrigger>
-
-              <SelectContent>
-                <SelectGroup>
-                  {REGION_OPTIONS.map((location) => (
-                    <SelectItem key={location} value={location}>
-                      {location}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
         <div>
           <Label className=" mb-5">
             나이 <span className="text-danger">*</span>

--- a/src/components/post/Form/Info/index.tsx
+++ b/src/components/post/Form/Info/index.tsx
@@ -1,6 +1,15 @@
-import { Label } from '@/components/ui'
+import {
+  Label,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui'
 import { Input } from '@/components/ui/input'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { AGE_OPTIONS, GENDER_OPTIONS, REGION_OPTIONS } from '@/constants/posts'
 
 interface InfoProps {
   region: string
@@ -26,30 +35,7 @@ export default function Info({
   return (
     <>
       <div>
-        <Label className=" mb-2">
-          국가 <span className="text-danger">*</span>
-        </Label>
-
-        <div className="relative">
-          <select
-            value={region}
-            onChange={(e) => onChangeRegion(e.target.value)}
-            className="w-full px-4 py-2.5 rounded-lg text-sm text-text-input appearance-none bg-[#EDF4FB] outline-none"
-          >
-            <option value="">국가를 선택해주세요</option>
-            <option value="korea">대한민국</option>
-            <option value="japan">일본</option>
-            <option value="usa">미국</option>
-          </select>
-
-          <span className="absolute right-4 top-1/2 -translate-y-1/2 text-text-input pointer-events-none">
-            ▼
-          </span>
-        </div>
-      </div>
-
-      <div>
-        <Label className="mb-2">
+        <Label className="mb-3">
           모집 정원 <span className="text-danger">*</span>
         </Label>
 
@@ -66,39 +52,63 @@ export default function Info({
             onValueChange={onChangeGender}
             className="flex gap-3 items-center"
           >
-            <Label className="flex items-center gap-2 cursor-pointer">
-              <RadioGroupItem value="남성" />
-              <span className=" text-sm">남성만</span>
-            </Label>
-
-            <Label className="flex items-center gap-2 cursor-pointer">
-              <RadioGroupItem value="여성" />
-              <span className="text-sm">여성만</span>
-            </Label>
-
-            <Label className="flex items-center gap-2 cursor-pointer">
-              <RadioGroupItem value="모두" />
-              <span className=" text-sm">모두</span>
-            </Label>
+            {GENDER_OPTIONS.map((opt) => (
+              <Label
+                key={opt.value}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                <RadioGroupItem value={opt.value} />
+                <span className="text-sm">{opt.label}</span>
+              </Label>
+            ))}
           </RadioGroup>
         </div>
       </div>
+      <div className="flex items-center justify-between">
+        <div>
+          <Label className=" mb-3">
+            국가 <span className="text-danger">*</span>
+          </Label>
 
-      <div>
-        <Label className=" mb-2">
-          나이 <span className="text-danger">*</span>
-        </Label>
+          <div className="relative">
+            <Select value={region} onValueChange={onChangeRegion}>
+              <SelectTrigger>
+                <SelectValue placeholder="국가를 선택해주세요" />
+              </SelectTrigger>
 
-        <select
-          value={age}
-          onChange={(e) => onChangeAge(e.target.value)}
-          className="flex-1 px-4 py-2.5 rounded-lg text-sm text-text-input appearance-none bg-[#EDF4FB] outline-none"
-        >
-          <option value="">출생년도 선택해주세요</option>
-          <option value="2005">2005년</option>
-          <option value="2000">2000년</option>
-          <option value="1995">1995년</option>
-        </select>
+              <SelectContent>
+                <SelectGroup>
+                  {REGION_OPTIONS.map((location) => (
+                    <SelectItem key={location} value={location}>
+                      {location}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div>
+          <Label className=" mb-5">
+            나이 <span className="text-danger">*</span>
+          </Label>
+
+          <RadioGroup
+            value={age}
+            onValueChange={onChangeAge}
+            className="flex gap-3 items-center mb-3"
+          >
+            {AGE_OPTIONS.map((opt) => (
+              <Label
+                key={opt.value}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                <RadioGroupItem value={opt.value} />
+                <span className="text-sm">{opt.label}</span>
+              </Label>
+            ))}
+          </RadioGroup>
+        </div>
       </div>
     </>
   )

--- a/src/components/post/Form/Info/index.tsx
+++ b/src/components/post/Form/Info/index.tsx
@@ -12,21 +12,21 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { AGE_OPTIONS, GENDER_OPTIONS, REGION_OPTIONS } from '@/constants/posts'
 
 interface InfoProps {
+  nation: string
   region: string
-  city: string
   member: string
   age: string
   gender: string
   onChangeMember: (v: string) => void
   onChangeRegion: (v: string) => void
-  onChangeCity: (v: string) => void
+  onChangeNation: (v: string) => void
   onChangeAge: (v: string) => void
   onChangeGender: (v: string) => void
 }
 
 export default function Info({
+  nation,
   region,
-  city,
   member,
   age,
   gender,
@@ -34,7 +34,7 @@ export default function Info({
   onChangeRegion,
   onChangeAge,
   onChangeGender,
-  onChangeCity,
+  onChangeNation,
 }: InfoProps) {
   return (
     <>
@@ -66,7 +66,7 @@ export default function Info({
             도시 <span className="text-danger">*</span>
           </Label>
           <div className="relative">
-            <Select value={city} onValueChange={onChangeCity}>
+            <Select value={nation} onValueChange={onChangeNation}>
               <SelectTrigger className=" w-full">
                 <SelectValue placeholder="도시를 선택해주세요" />
               </SelectTrigger>

--- a/src/components/post/Form/Info/index.tsx
+++ b/src/components/post/Form/Info/index.tsx
@@ -36,59 +36,63 @@ export default function Info({
   onChangeGender,
   onChangeNation,
 }: InfoProps) {
+  const LABEL = 'mb-3'
+  const RADIO_LABEL = 'flex items-center gap-2 cursor-pointer'
+  const FLEX_ROW = 'flex gap-4 items-center'
+  const SECTION = 'mt-6'
+
   return (
     <>
       <div className="flex gap-4">
         <div className="w-1/2">
-          <Label className=" mb-3">
+          <Label className={LABEL}>
             국가 <span className="text-danger">*</span>
           </Label>
 
-          <div className="relative">
-            <Select value={region} onValueChange={onChangeRegion}>
-              <SelectTrigger className=" w-full">
-                <SelectValue placeholder="국가를 선택해주세요" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  {REGION_OPTIONS.map((location) => (
-                    <SelectItem key={location} value={location}>
-                      {location}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
+          <Select value={nation} onValueChange={onChangeNation}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="국가를 선택해주세요" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {REGION_OPTIONS.map((location) => (
+                  <SelectItem key={location} value={location}>
+                    {location}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
         </div>
+
         <div className="w-1/2">
-          <Label className=" mb-3">
+          <Label className={LABEL}>
             도시 <span className="text-danger">*</span>
           </Label>
-          <div className="relative">
-            <Select value={nation} onValueChange={onChangeNation}>
-              <SelectTrigger className=" w-full">
-                <SelectValue placeholder="도시를 선택해주세요" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  {REGION_OPTIONS.map((location) => (
-                    <SelectItem key={location} value={location}>
-                      {location}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
+
+          <Select value={region} onValueChange={onChangeRegion}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="도시를 선택해주세요" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {REGION_OPTIONS.map((location) => (
+                  <SelectItem key={location} value={location}>
+                    {location}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
         </div>
       </div>
-      <div>
-        <Label className="mb-3">
+
+      <div className={SECTION}>
+        <Label className={LABEL}>
           모집 정원 <span className="text-danger">*</span>
         </Label>
 
-        <div className="flex gap-4 items-center">
+        <div className={FLEX_ROW}>
           <Input
             value={member}
             onChange={(e) => onChangeMember(e.target.value)}
@@ -102,10 +106,7 @@ export default function Info({
             className="flex gap-3 items-center"
           >
             {GENDER_OPTIONS.map((opt) => (
-              <Label
-                key={opt.value}
-                className="flex items-center gap-2 cursor-pointer"
-              >
+              <Label key={opt.value} className={RADIO_LABEL}>
                 <RadioGroupItem value={opt.value} />
                 <span className="text-sm">{opt.label}</span>
               </Label>
@@ -113,28 +114,24 @@ export default function Info({
           </RadioGroup>
         </div>
       </div>
-      <div className="flex items-center justify-between">
-        <div>
-          <Label className=" mb-5">
-            나이 <span className="text-danger">*</span>
-          </Label>
 
-          <RadioGroup
-            value={age}
-            onValueChange={onChangeAge}
-            className="flex gap-3 items-center mb-3"
-          >
-            {AGE_OPTIONS.map((opt) => (
-              <Label
-                key={opt.value}
-                className="flex items-center gap-2 cursor-pointer"
-              >
-                <RadioGroupItem value={opt.value} />
-                <span className="text-sm">{opt.label}</span>
-              </Label>
-            ))}
-          </RadioGroup>
-        </div>
+      <div className={SECTION}>
+        <Label className={LABEL}>
+          나이 <span className="text-danger">*</span>
+        </Label>
+
+        <RadioGroup
+          value={age}
+          onValueChange={onChangeAge}
+          className="flex gap-3 items-center mb-3"
+        >
+          {AGE_OPTIONS.map((opt) => (
+            <Label key={opt.value} className={RADIO_LABEL}>
+              <RadioGroupItem value={opt.value} />
+              <span className="text-sm">{opt.label}</span>
+            </Label>
+          ))}
+        </RadioGroup>
       </div>
     </>
   )

--- a/src/components/post/Form/Info/index.tsx
+++ b/src/components/post/Form/Info/index.tsx
@@ -1,26 +1,34 @@
+import { Label } from '@/components/ui'
+import { Input } from '@/components/ui/input'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+
 interface InfoProps {
   region: string
   member: string
   age: string
+  gender: string
   onChangeMember: (v: string) => void
   onChangeRegion: (v: string) => void
   onChangeAge: (v: string) => void
+  onChangeGender: (v: string) => void
 }
 
 export default function Info({
   region,
   member,
   age,
+  gender,
   onChangeMember,
   onChangeRegion,
   onChangeAge,
+  onChangeGender,
 }: InfoProps) {
   return (
     <>
       <div>
-        <label className="block text-sm text-text-base mb-3">
+        <Label className=" mb-2">
           국가 <span className="text-danger">*</span>
-        </label>
+        </Label>
 
         <div className="relative">
           <select
@@ -41,38 +49,56 @@ export default function Info({
       </div>
 
       <div>
-        <label className="block text-sm text-text-base mb-2">
+        <Label className="mb-2">
           모집 정원 <span className="text-danger">*</span>
-        </label>
+        </Label>
 
-        <div className="flex gap-4">
-          <input
-            type="text"
+        <div className="flex gap-4 items-center">
+          <Input
             value={member}
             onChange={(e) => onChangeMember(e.target.value)}
             placeholder="인원을 입력해주세요"
-            className="w-1/2 px-4 py-2.5 rounded-lg text-sm bg-[#EDF4FB] placeholder:text-text-input outline-none"
+            className="w-1/2"
           />
+
+          <RadioGroup
+            value={gender}
+            onValueChange={onChangeGender}
+            className="flex gap-3 items-center"
+          >
+            <Label className="flex items-center gap-2 cursor-pointer">
+              <RadioGroupItem value="남성" />
+              <span className=" text-sm">남성만</span>
+            </Label>
+
+            <Label className="flex items-center gap-2 cursor-pointer">
+              <RadioGroupItem value="여성" />
+              <span className="text-sm">여성만</span>
+            </Label>
+
+            <Label className="flex items-center gap-2 cursor-pointer">
+              <RadioGroupItem value="모두" />
+              <span className=" text-sm">모두</span>
+            </Label>
+          </RadioGroup>
         </div>
       </div>
 
       <div>
-        <label className="block text-sm text-text-base mb-2">
+        <Label className=" mb-2">
           나이 <span className="text-danger">*</span>
-        </label>
+        </Label>
 
-        <div className="flex gap-3 items-center">
-          <select
-            value={age}
-            onChange={(e) => onChangeAge(e.target.value)}
-            className="flex-1 px-4 py-2.5 rounded-lg text-sm text-text-input appearance-none bg-[#EDF4FB] outline-none"
-          >
-            <option value="">출생년도 선택해주세요</option>
-            <option value="2005">2005년</option>
-            <option value="2000">2000년</option>
-            <option value="1995">1995년</option>
-          </select>
-        </div>
+        <select
+          value={age}
+          onChange={(e) => onChangeAge(e.target.value)}
+          className="flex-1 px-4 py-2.5 rounded-lg text-sm text-text-input appearance-none bg-[#EDF4FB] outline-none"
+        >
+          <option value="">출생년도 선택해주세요</option>
+          <option value="2005">2005년</option>
+          <option value="2000">2000년</option>
+          <option value="1995">1995년</option>
+        </select>
       </div>
     </>
   )

--- a/src/components/post/Form/index.tsx
+++ b/src/components/post/Form/index.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { FormEvent, useState } from 'react'
 
 import { Button } from '@/components/common'
+import { AgeType, GenderType } from '@/types/posts'
 
 import Date from './Date'
 import Description from './Description'
@@ -17,77 +18,100 @@ export default function PostForm() {
     description: '',
     region: '',
     member: '',
-    age: '',
-    gender: '',
+    age: '' as AgeType | '',
+    gender: '' as GenderType | '',
     startDate: null as Date | null,
     endDate: null as Date | null,
     tags: [] as string[],
     images: [] as string[],
   })
+
   const router = useRouter()
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    if (!form.age || !form.gender || !form.startDate || !form.endDate) {
+      alert('모든 필드를 입력해주세요.')
+      return
+    }
+
+    const payload = {
+      title: form.title,
+      content: form.description,
+      region: form.region,
+      startDate: form.startDate.toISOString().split('T')[0],
+      endDate: form.endDate.toISOString().split('T')[0],
+      maxMembers: parseInt(form.member) || 0,
+      tags: form.tags,
+      images: form.images,
+      genderType: form.gender as GenderType,
+      ageType: form.age as AgeType,
+    }
+  }
+
   return (
-    <>
-      <div className="flex flex-col  items-center">
-        <div className="max-w-7xl w-full px-8">
-          <h1 className="text-2xl font-semibold mb-6 text-left">게시글 작성</h1>
-        </div>
-        <div className=" max-w-7xl flex items-center justify-center">
-          <div className="space-y-6 ">
-            <Header
-              title={form.title}
-              tags={form.tags}
-              onChangeTitle={(v) => setForm((prev) => ({ ...prev, title: v }))}
-              onChangeTags={(text) => {
-                const tags = text.map((t) => t.trim()).filter((t) => t !== '')
-                setForm((prev) => ({ ...prev, tags }))
-              }}
-            />
-            <ImageUpload />
-            <Info
-              region={form.region}
-              member={form.member}
-              age={form.age}
-              gender={form.gender}
-              onChangeRegion={(v) =>
-                setForm((prev) => ({ ...prev, region: v }))
-              }
-              onChangeMember={(v) =>
-                setForm((prev) => ({ ...prev, member: v }))
-              }
-              onChangeAge={(v) => setForm((prev) => ({ ...prev, age: v }))}
-              onChangeGender={(v) =>
-                setForm((prev) => ({ ...prev, gender: v }))
-              }
-            />
-            <Date
-              startDate={form.startDate}
-              endDate={form.endDate}
-              onChangeStartDate={(v) =>
-                setForm((prev) => ({ ...prev, startDate: v }))
-              }
-              onChangeEndDate={(v) =>
-                setForm((prev) => ({ ...prev, endDate: v }))
-              }
-            />
-            <Description
-              description={form.description}
-              onChangeDescription={(v) =>
-                setForm((prev) => ({ ...prev, description: v }))
-              }
-            />
-            <div className="flex items-center gap-8 justify-center">
-              <Button
-                size="md"
-                variant="secondary"
-                onClick={() => router.push('/')}
-              >
-                나가기
-              </Button>
-              <Button size="md">게시글 등록</Button>
-            </div>
-          </div>
-        </div>
+    <div className="flex flex-col items-center">
+      <div className="max-w-7xl w-full px-8">
+        <h1 className="text-2xl font-semibold mb-6 text-left">게시글 작성</h1>
       </div>
-    </>
+      <div className="max-w-7xl flex items-center justify-center">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <Header
+            title={form.title}
+            tags={form.tags}
+            onChangeTitle={(v) => setForm((prev) => ({ ...prev, title: v }))}
+            onChangeTags={(text) => {
+              const tags = text.map((t) => t.trim()).filter((t) => t !== '')
+              setForm((prev) => ({ ...prev, tags }))
+            }}
+          />
+          <ImageUpload />
+          <Info
+            region={form.region}
+            member={form.member}
+            age={form.age}
+            gender={form.gender}
+            onChangeRegion={(v) => setForm((prev) => ({ ...prev, region: v }))}
+            onChangeMember={(v) => setForm((prev) => ({ ...prev, member: v }))}
+            onChangeAge={(v) =>
+              setForm((prev) => ({ ...prev, age: v as AgeType }))
+            }
+            onChangeGender={(v) =>
+              setForm((prev) => ({ ...prev, gender: v as GenderType }))
+            }
+          />
+          <Date
+            startDate={form.startDate}
+            endDate={form.endDate}
+            onChangeStartDate={(v) =>
+              setForm((prev) => ({ ...prev, startDate: v }))
+            }
+            onChangeEndDate={(v) =>
+              setForm((prev) => ({ ...prev, endDate: v }))
+            }
+          />
+          <Description
+            description={form.description}
+            onChangeDescription={(v) =>
+              setForm((prev) => ({ ...prev, description: v }))
+            }
+          />
+          <div className="flex items-center gap-8 justify-center">
+            <Button
+              type="button"
+              size="md"
+              variant="secondary"
+              onClick={() => router.push('/')}
+            >
+              나가기
+            </Button>
+            <Button type="submit" size="md">
+              게시글 등록
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
   )
 }

--- a/src/components/post/Form/index.tsx
+++ b/src/components/post/Form/index.tsx
@@ -17,6 +17,7 @@ export default function PostForm() {
     title: '',
     description: '',
     region: '',
+    city: '',
     member: '',
     age: '' as AgeType | '',
     gender: '' as GenderType | '',
@@ -69,10 +70,12 @@ export default function PostForm() {
           <ImageUpload />
           <Info
             region={form.region}
+            city={form.city}
             member={form.member}
             age={form.age}
             gender={form.gender}
             onChangeRegion={(v) => setForm((prev) => ({ ...prev, region: v }))}
+            onChangeCity={(v) => setForm((prev) => ({ ...prev, city: v }))}
             onChangeMember={(v) => setForm((prev) => ({ ...prev, member: v }))}
             onChangeAge={(v) =>
               setForm((prev) => ({ ...prev, age: v as AgeType }))

--- a/src/components/post/Form/index.tsx
+++ b/src/components/post/Form/index.tsx
@@ -16,8 +16,8 @@ export default function PostForm() {
   const [form, setForm] = useState({
     title: '',
     description: '',
+    nation: '',
     region: '',
-    city: '',
     member: '',
     age: '' as AgeType | '',
     gender: '' as GenderType | '',
@@ -69,13 +69,13 @@ export default function PostForm() {
           />
           <ImageUpload />
           <Info
+            nation={form.nation}
             region={form.region}
-            city={form.city}
             member={form.member}
             age={form.age}
             gender={form.gender}
             onChangeRegion={(v) => setForm((prev) => ({ ...prev, region: v }))}
-            onChangeCity={(v) => setForm((prev) => ({ ...prev, city: v }))}
+            onChangeNation={(v) => setForm((prev) => ({ ...prev, nation: v }))}
             onChangeMember={(v) => setForm((prev) => ({ ...prev, member: v }))}
             onChangeAge={(v) =>
               setForm((prev) => ({ ...prev, age: v as AgeType }))

--- a/src/components/post/Form/index.tsx
+++ b/src/components/post/Form/index.tsx
@@ -18,6 +18,7 @@ export default function PostForm() {
     region: '',
     member: '',
     age: '',
+    gender: '',
     startDate: null as Date | null,
     endDate: null as Date | null,
     tags: [] as string[],
@@ -37,10 +38,7 @@ export default function PostForm() {
               tags={form.tags}
               onChangeTitle={(v) => setForm((prev) => ({ ...prev, title: v }))}
               onChangeTags={(text) => {
-                const tags = text
-                  .split(',')
-                  .map((t) => t.trim())
-                  .filter((t) => t !== '')
+                const tags = text.map((t) => t.trim()).filter((t) => t !== '')
                 setForm((prev) => ({ ...prev, tags }))
               }}
             />
@@ -49,13 +47,17 @@ export default function PostForm() {
               region={form.region}
               member={form.member}
               age={form.age}
-              onChangeMember={(v) =>
-                setForm((prev) => ({ ...prev, member: v }))
-              }
+              gender={form.gender}
               onChangeRegion={(v) =>
                 setForm((prev) => ({ ...prev, region: v }))
               }
+              onChangeMember={(v) =>
+                setForm((prev) => ({ ...prev, member: v }))
+              }
               onChangeAge={(v) => setForm((prev) => ({ ...prev, age: v }))}
+              onChangeGender={(v) =>
+                setForm((prev) => ({ ...prev, gender: v }))
+              }
             />
             <Date
               startDate={form.startDate}

--- a/src/components/post/Form/index.tsx
+++ b/src/components/post/Form/index.tsx
@@ -32,7 +32,7 @@ export default function PostForm() {
           <h1 className="text-2xl font-semibold mb-6 text-left">게시글 작성</h1>
         </div>
         <div className=" max-w-7xl flex items-center justify-center">
-          <div className="space-y-2.5 ">
+          <div className="space-y-6 ">
             <Header
               title={form.title}
               tags={form.tags}

--- a/src/components/post/List/FilterBar/index.tsx
+++ b/src/components/post/List/FilterBar/index.tsx
@@ -49,7 +49,7 @@ export default function FilterBar({
             onChangeFilters((prev) => ({ ...prev, region: value }))
           }
         >
-          <SelectTrigger className="rounded-xl bg-bg-disabled">
+          <SelectTrigger>
             <SelectValue placeholder="지역" />
           </SelectTrigger>
           <SelectContent>
@@ -68,7 +68,7 @@ export default function FilterBar({
             onChangeFilters((prev) => ({ ...prev, date: value }))
           }
         >
-          <SelectTrigger className=" rounded-xl bg-bg-disabled">
+          <SelectTrigger>
             <SelectValue placeholder="날짜" />
           </SelectTrigger>
           <SelectContent>
@@ -82,7 +82,7 @@ export default function FilterBar({
             onChangeFilters((prev) => ({ ...prev, age: value }))
           }
         >
-          <SelectTrigger className="rounded-xl bg-bg-disabled">
+          <SelectTrigger>
             <SelectValue placeholder="나이" />
           </SelectTrigger>
           <SelectContent>
@@ -104,7 +104,7 @@ export default function FilterBar({
             }))
           }
         >
-          <SelectTrigger className=" rounded-xl bg-bg-disabled">
+          <SelectTrigger>
             <SelectValue placeholder="성별" />
           </SelectTrigger>
           <SelectContent>

--- a/src/components/post/List/FilterBar/index.tsx
+++ b/src/components/post/List/FilterBar/index.tsx
@@ -1,4 +1,3 @@
-// FilterBar.tsx
 'use client'
 
 import { Plus, Search } from 'lucide-react'
@@ -13,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select/select.components'
+import { InputGroup, InputGroupInput } from '@/components/ui'
 import { AGE_OPTIONS, GENDER_OPTIONS, REGION_OPTIONS } from '@/constants/posts'
 import { GenderType, PostParams } from '@/types/posts'
 
@@ -42,14 +42,14 @@ export default function FilterBar({
 
   return (
     <div className="max-w-7xl mx-auto px-4 py-4 flex gap-2 justify-between">
-      <div className="flex gap-2">
+      <div className="flex gap-4">
         <SelectRoot
           value={filters.region}
           onValueChange={(value) =>
             onChangeFilters((prev) => ({ ...prev, region: value }))
           }
         >
-          <SelectTrigger className="h-10 rounded-xl bg-bg-disabled">
+          <SelectTrigger className="rounded-xl bg-bg-disabled">
             <SelectValue placeholder="지역" />
           </SelectTrigger>
           <SelectContent>
@@ -68,7 +68,7 @@ export default function FilterBar({
             onChangeFilters((prev) => ({ ...prev, date: value }))
           }
         >
-          <SelectTrigger className="h-10 rounded-xl bg-bg-disabled">
+          <SelectTrigger className=" rounded-xl bg-bg-disabled">
             <SelectValue placeholder="날짜" />
           </SelectTrigger>
           <SelectContent>
@@ -82,7 +82,7 @@ export default function FilterBar({
             onChangeFilters((prev) => ({ ...prev, age: value }))
           }
         >
-          <SelectTrigger className="h-10 rounded-xl bg-bg-disabled">
+          <SelectTrigger className="rounded-xl bg-bg-disabled">
             <SelectValue placeholder="나이" />
           </SelectTrigger>
           <SelectContent>
@@ -104,7 +104,7 @@ export default function FilterBar({
             }))
           }
         >
-          <SelectTrigger className="h-10 rounded-xl bg-bg-disabled">
+          <SelectTrigger className=" rounded-xl bg-bg-disabled">
             <SelectValue placeholder="성별" />
           </SelectTrigger>
           <SelectContent>
@@ -118,14 +118,13 @@ export default function FilterBar({
       </div>
 
       <div className="flex-1 relative max-w-[456px]">
-        <input
-          type="text"
-          value={keywordInput}
-          onChange={handleSearchChange}
-          placeholder="검색어를 입력해 주세요"
-          className="w-full px-4 py-2 pr-10 border border-border rounded-lg text-sm bg-bg-disabled text-text-base placeholder:text-text-input"
-        />
-        <Search className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-text-input pointer-events-none" />
+        <InputGroup>
+          <InputGroupInput
+            placeholder="검색어를 입력해주세요"
+            onChange={handleSearchChange}
+          />
+          <Search className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-text-input pointer-events-none" />
+        </InputGroup>
       </div>
 
       <Button

--- a/src/components/post/List/FilterBar/index.tsx
+++ b/src/components/post/List/FilterBar/index.tsx
@@ -13,13 +13,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/common/Select/select.components'
-import {
-  AGE_OPTIONS,
-  AGE_TYPE_OPTIONS,
-  GENDER_OPTIONS,
-  REGION_OPTIONS,
-} from '@/constants/posts'
-import { AgeType, GenderType, PostParams } from '@/types/posts'
+import { AGE_OPTIONS, GENDER_OPTIONS, REGION_OPTIONS } from '@/constants/posts'
+import { GenderType, PostParams } from '@/types/posts'
 
 interface FilterBarProps {
   filters: PostParams
@@ -93,26 +88,8 @@ export default function FilterBar({
           <SelectContent>
             <SelectItem value="">전체</SelectItem>
             {AGE_OPTIONS.map((age) => (
-              <SelectItem key={age} value={String(age)}>
-                {age}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </SelectRoot>
-
-        <SelectRoot
-          value={filters.ageType}
-          onValueChange={(value) =>
-            onChangeFilters((prev) => ({ ...prev, ageType: value as AgeType }))
-          }
-        >
-          <SelectTrigger className="h-10 rounded-xl bg-bg-disabled">
-            <SelectValue placeholder="나이 조건" />
-          </SelectTrigger>
-          <SelectContent>
-            {AGE_TYPE_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
+              <SelectItem key={age.value} value={String(age.label)}>
+                {age.value}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/components/post/List/FilterBar/index.tsx
+++ b/src/components/post/List/FilterBar/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/common/Select/select.components'
 import { InputGroup, InputGroupInput } from '@/components/ui'
 import { AGE_OPTIONS, GENDER_OPTIONS, REGION_OPTIONS } from '@/constants/posts'
-import { GenderType, PostParams } from '@/types/posts'
+import { AgeType, GenderType, PostParams } from '@/types/posts'
 
 interface FilterBarProps {
   filters: PostParams
@@ -77,18 +77,20 @@ export default function FilterBar({
         </SelectRoot>
 
         <SelectRoot
-          value={filters.age}
+          value={filters.ageType ?? ''}
           onValueChange={(value) =>
-            onChangeFilters((prev) => ({ ...prev, age: value }))
+            onChangeFilters((prev) => ({ ...prev, ageType: value as AgeType }))
           }
         >
           <SelectTrigger>
             <SelectValue placeholder="나이" />
           </SelectTrigger>
+
           <SelectContent>
             <SelectItem value="">전체</SelectItem>
+
             {AGE_OPTIONS.map((age) => (
-              <SelectItem key={age.value} value={String(age.label)}>
+              <SelectItem key={age.value} value={age.value}>
                 {age.label}
               </SelectItem>
             ))}

--- a/src/components/post/List/FilterBar/index.tsx
+++ b/src/components/post/List/FilterBar/index.tsx
@@ -44,9 +44,9 @@ export default function FilterBar({
     <div className="max-w-7xl mx-auto px-4 py-4 flex gap-2 justify-between">
       <div className="flex gap-4">
         <SelectRoot
-          value={filters.region}
+          value={filters.nation}
           onValueChange={(value) =>
-            onChangeFilters((prev) => ({ ...prev, region: value }))
+            onChangeFilters((prev) => ({ ...prev, nation: value }))
           }
         >
           <SelectTrigger>

--- a/src/components/post/List/FilterBar/index.tsx
+++ b/src/components/post/List/FilterBar/index.tsx
@@ -89,7 +89,7 @@ export default function FilterBar({
             <SelectItem value="">전체</SelectItem>
             {AGE_OPTIONS.map((age) => (
               <SelectItem key={age.value} value={String(age.label)}>
-                {age.value}
+                {age.label}
               </SelectItem>
             ))}
           </SelectContent>
@@ -108,6 +108,7 @@ export default function FilterBar({
             <SelectValue placeholder="성별" />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="">전체</SelectItem>
             {GENDER_OPTIONS.map((option) => (
               <SelectItem key={option.value} value={option.value}>
                 {option.label}

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -65,6 +65,7 @@ export default function PostCard({ post }: { post: PostContent }) {
           <div className="flex items-center gap-2 text-sm text-text-input">
             <div className="flex items-center gap-1">
               <span className="text-text-disabled">위치</span>
+              <span className="text-text-base">{post.nation}</span>
               <span className="text-text-base">{post.region}</span>
             </div>
 

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -11,7 +11,7 @@ export default function PostCard({ post }: { post: PostContent }) {
   const router = useRouter()
   const tagStyle = 'px-3 py-1 bg-blue-50 text-main rounded-full text-xs'
   const cardBase =
-    'bg-white rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow border border-border'
+    'bg-white rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow border border-input'
 
   return (
     <div

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -23,7 +23,7 @@ export default function PostCard({ post }: { post: PostContent }) {
           <div className="relative w-[188px] h-[188px] rounded-2xl overflow-hidden shrink-0  bg-black/60 flex items-center justify-center">
             <p className="text-white">모집이 마감되었어요.</p>
             <Image
-              src={post.thumbnail}
+              src={post.thumbnail[0]}
               alt={post.title}
               fill
               className="object-cover"
@@ -32,7 +32,7 @@ export default function PostCard({ post }: { post: PostContent }) {
         ) : (
           <div className="relative w-[188px] h-[188px] rounded-2xl overflow-hidden shrink-0 bg-bg-disabled">
             <Image
-              src={post.thumbnail}
+              src={post.thumbnail[0]}
               alt={post.title}
               fill
               className="object-cover"

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -9,18 +9,22 @@ import { PostContent } from '@/types/posts'
 
 export default function PostCard({ post }: { post: PostContent }) {
   const router = useRouter()
-  const tagStyle = 'px-3 py-1 bg-blue-50 text-main rounded-full text-xs'
-  const cardBase =
+
+  const TAG_STYLE = 'px-3 py-1 bg-blue-50 text-main rounded-full text-xs'
+  const CARD_BASE =
     'bg-white rounded-2xl p-6 shadow-sm hover:shadow-md transition-shadow border border-input'
+  const LABEL = 'text-text-disabled'
+  const VALUE = 'text-text-base'
+  const INFO_ROW = 'flex items-center gap-1'
 
   return (
     <div
-      className={cardBase}
+      className={CARD_BASE}
       onClick={() => router.push(`/posts/${post.postId}`)}
     >
       <div className="flex gap-4">
         {post.recruitStatus === 'CLOSED' ? (
-          <div className="relative w-[188px] h-[188px] rounded-2xl overflow-hidden shrink-0  bg-black/60 flex items-center justify-center">
+          <div className="relative w-[188px] h-[188px] rounded-2xl overflow-hidden shrink-0 bg-black/60 flex items-center justify-center">
             <p className="text-white">모집이 마감되었어요.</p>
             <Image
               src={post.thumbnail[0]}
@@ -39,10 +43,11 @@ export default function PostCard({ post }: { post: PostContent }) {
             />
           </div>
         )}
+
         <div className="flex-1 ml-3">
           <div className="flex gap-2 mb-2">
             {post.tags.map((tag) => (
-              <span key={tag} className={tagStyle}>
+              <span key={tag} className={TAG_STYLE}>
                 {tag}
               </span>
             ))}
@@ -63,17 +68,17 @@ export default function PostCard({ post }: { post: PostContent }) {
           </div>
 
           <div className="flex items-center gap-2 text-sm text-text-input">
-            <div className="flex items-center gap-1">
-              <span className="text-text-disabled">위치</span>
-              <span className="text-text-base">{post.nation}</span>
-              <span className="text-text-base">{post.region}</span>
+            <div className={INFO_ROW}>
+              <span className={LABEL}>위치</span>
+              <span className={VALUE}>{post.nation}</span>
+              <span className={VALUE}>{post.region}</span>
             </div>
 
-            <span className="text-text-disabled">|</span>
+            <span className={LABEL}>|</span>
 
-            <div className="flex items-center gap-1">
-              <span className="text-text-disabled">날짜</span>
-              <span className="text-text-base">
+            <div className={INFO_ROW}>
+              <span className={LABEL}>날짜</span>
+              <span className={VALUE}>
                 {new Date(post.period.startDate).toLocaleDateString('ko-KR', {
                   month: 'long',
                   day: 'numeric',
@@ -81,22 +86,18 @@ export default function PostCard({ post }: { post: PostContent }) {
               </span>
             </div>
 
-            <span className="text-text-disabled">|</span>
+            <span className={LABEL}>|</span>
 
-            <div className="flex items-center gap-1">
-              <span className="text-text-disabled">나이</span>
-              <span className="text-text-base">
-                {post.conditions.ageCondition}
-              </span>
+            <div className={INFO_ROW}>
+              <span className={LABEL}>나이</span>
+              <span className={VALUE}>{post.conditions.ageCondition}</span>
             </div>
 
-            <span className="text-text-disabled">|</span>
+            <span className={LABEL}>|</span>
 
-            <div className="flex items-center gap-1">
-              <span className="text-text-disabled">성별</span>
-              <span className="text-text-base">
-                {post.conditions.genderCondition}
-              </span>
+            <div className={INFO_ROW}>
+              <span className={LABEL}>성별</span>
+              <span className={VALUE}>{post.conditions.genderCondition}</span>
             </div>
           </div>
         </div>

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -101,10 +101,10 @@ export default function PostCard({ post }: { post: PostContent }) {
         </div>
 
         <div className="flex flex-col items-end justify-between">
-          <button className="w-10 h-10 flex items-center justify-center hover:bg-bg-input rounded-full transition-colors">
+          <button className="w-10 h-10 flex items-center justify-center rounded-full transition-colors">
             <Heart
               className={`w-6 h-6 ${
-                post.bookmarked ? 'fill-main text-main' : 'text-text-input'
+                post.isBookmarked ? 'fill-main text-main' : 'text-text-input'
               }`}
             />
           </button>

--- a/src/components/post/List/index.tsx
+++ b/src/components/post/List/index.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 
 import { Button } from '@/components/common'
-import { AgeType, GenderType, PostContent, PostParams } from '@/types/posts'
+import { PostContent, PostParams } from '@/types/posts'
 
 import FilterBar from './FilterBar'
 import PostListSection from './PostListSection'
@@ -12,8 +12,8 @@ export default function PostList() {
   const [filters, setFilters] = useState<PostParams>({
     region: '',
     date: '',
-    ageType: '' as AgeType,
-    gender: '' as GenderType,
+    ageType: undefined,
+    gender: undefined,
     keyword: '',
   })
 

--- a/src/components/post/List/index.tsx
+++ b/src/components/post/List/index.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 
 import { Button } from '@/components/common'
-import { PostContent, PostParams } from '@/types/posts'
+import { AgeType, GenderType, PostContent, PostParams } from '@/types/posts'
 
 import FilterBar from './FilterBar'
 import PostListSection from './PostListSection'
@@ -12,40 +12,40 @@ export default function PostList() {
   const [filters, setFilters] = useState<PostParams>({
     region: '',
     date: '',
-    age: '',
-    ageType: '',
-    gender: '',
+    ageType: '' as AgeType,
+    gender: '' as GenderType,
     keyword: '',
   })
 
   // 임시 데이터
   const mockPosts: PostContent[] = [
     {
-      postId: 'post-1',
-      title: '도쿄 디즈니 2박 3일 급구!',
-      region: '일본 도쿄',
+      postId: '1',
+      title: '베트남 여행 같이 가실 분~',
+      content: '베트남 여행 같이 가실 분 모집합니다!',
+      region: '베트남',
       period: {
-        startDate: '2025-01-10',
-        endDate: '2025-01-12',
+        startDate: '2024-12-15',
+        endDate: '2024-12-20',
       },
       recruitStatus: 'RECRUITING',
-      tags: ['힐링', '맛집', '쇼핑'],
-      nickname: '푸우님과함께',
+      tags: ['여행', '베트남'],
+      nickname: '여행러버',
       currentMembers: 2,
       maxMembers: 4,
       conditions: {
-        ageCondition: '20대',
-        birthYear: 2000,
-        genderCondition: '여성만',
+        ageCondition: 'TWENTY',
+        genderCondition: 'FEMALE',
       },
-      bookmarked: true,
-      thumbnail: '/',
-      createdAt: String(new Date()),
-      updatedAt: '',
+      isBookmarked: false,
+      thumbnail: ['/'],
+      createdAt: '2024-12-01',
+      updatedAt: '2024-12-01',
     },
     {
       postId: 'post-2',
       title: '다낭 4박5일 가족여행 동행 구해요',
+      content: '가족 여행 동행 구합니다.',
       region: '베트남 다낭',
       period: {
         startDate: '2025-02-21',
@@ -57,18 +57,18 @@ export default function PostList() {
       currentMembers: 3,
       maxMembers: 3,
       conditions: {
-        ageCondition: '30대',
-        birthYear: 1993,
-        genderCondition: '누구나',
+        ageCondition: 'THIRTY',
+        genderCondition: 'ALL',
       },
-      bookmarked: false,
-      thumbnail: '/',
-      createdAt: String(new Date()),
-      updatedAt: '',
+      isBookmarked: false,
+      thumbnail: ['/'],
+      createdAt: '2025-02-21',
+      updatedAt: '2025-02-21',
     },
     {
       postId: 'post-3',
       title: '제주도 한라산 등반 같이 가실 분!',
+      content: '한라산 등반 같이 가요!',
       region: '한국 제주도',
       period: {
         startDate: '2024-12-30',
@@ -80,14 +80,13 @@ export default function PostList() {
       currentMembers: 1,
       maxMembers: 2,
       conditions: {
-        ageCondition: '20대',
-        birthYear: 1993,
-        genderCondition: '누구나',
+        ageCondition: 'TWENTY',
+        genderCondition: 'ALL',
       },
-      bookmarked: true,
-      thumbnail: '/',
-      createdAt: String(new Date()),
-      updatedAt: '',
+      isBookmarked: true,
+      thumbnail: ['/'],
+      createdAt: '2024-12-30',
+      updatedAt: '2024-12-30',
     },
   ]
 

--- a/src/components/post/List/index.tsx
+++ b/src/components/post/List/index.tsx
@@ -10,7 +10,7 @@ import PostListSection from './PostListSection'
 
 export default function PostList() {
   const [filters, setFilters] = useState<PostParams>({
-    region: '',
+    nation: '',
     date: '',
     ageType: undefined,
     gender: undefined,
@@ -23,7 +23,8 @@ export default function PostList() {
       postId: '1',
       title: '베트남 여행 같이 가실 분~',
       content: '베트남 여행 같이 가실 분 모집합니다!',
-      region: '베트남',
+      nation: '베트남',
+      region: '다낭',
       period: {
         startDate: '2024-12-15',
         endDate: '2024-12-20',
@@ -46,7 +47,8 @@ export default function PostList() {
       postId: 'post-2',
       title: '다낭 4박5일 가족여행 동행 구해요',
       content: '가족 여행 동행 구합니다.',
-      region: '베트남 다낭',
+      nation: '베트남',
+      region: '다낭',
       period: {
         startDate: '2025-02-21',
         endDate: '2025-02-25',
@@ -69,7 +71,8 @@ export default function PostList() {
       postId: 'post-3',
       title: '제주도 한라산 등반 같이 가실 분!',
       content: '한라산 등반 같이 가요!',
-      region: '한국 제주도',
+      nation: '한국',
+      region: '제주도',
       period: {
         startDate: '2024-12-30',
         endDate: '2024-12-31',
@@ -95,6 +98,7 @@ export default function PostList() {
   // const { data,isLoading } = usePosts({
   //   lastPostId: cursor,
   //   size: 20,
+  //   nation: filters.nation || undefined.
   //   region: filters.region || undefined,
   //   date: filters.date || undefined, // yyyy-MM-dd 형식
   //   age: filters.age ? Number(filters.age) : undefined,

--- a/src/components/post/Skeleton/CommentSkeleton/index.tsx
+++ b/src/components/post/Skeleton/CommentSkeleton/index.tsx
@@ -1,36 +1,38 @@
+import { Skeleton } from '@/components/common'
+
 export default function CommentItemSkeleton() {
   return (
     <div className="w-4xl mr-auto p-4">
-      <div className="bg-blue-50 rounded-lg p-4 animate-pulse">
-        <div className="h-4 w-28 bg-gray-200 rounded-md mb-3" />
+      <div className=" rounded-lg p-4">
+        <Skeleton className="h-4 w-28  mb-3" />
 
-        <div className="w-full h-20 bg-gray-200 rounded-md" />
+        <Skeleton className="w-full h-20 " />
 
         <div className="flex justify-end gap-2 mt-3">
-          <div className="w-16 h-8 bg-gray-200 rounded-md" />
-          <div className="w-16 h-8 bg-gray-200 rounded-md" />
+          <Skeleton size="sm" />
+          <Skeleton size="sm" />
         </div>
       </div>
-      <div className="flex gap-4 pt-8 animate-pulse">
-        <div className="w-12 h-12 rounded-full bg-gray-200" />
+      <div className="flex gap-4 pt-8 ">
+        <Skeleton size="circle" className="w-12 h-12" />
 
         <div className="flex-1 space-y-2">
           <div className="flex items-center justify-between">
             <div className="space-y-2">
-              <div className="h-4 w-24 bg-gray-200 rounded-md" />
-              <div className="h-3 w-20 bg-gray-200 rounded-md" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-3 w-20" />
             </div>
 
-            <div className="w-4 h-4 bg-gray-200 rounded" />
+            <Skeleton size="circle" className="w-4 h-4 " />
           </div>
 
           <div className="space-y-2 mt-2">
-            <div className="h-4 w-2/3 bg-gray-200 rounded-md" />
+            <Skeleton className="w-2/3 " />
           </div>
 
           <div className="flex gap-4 mt-2">
-            <div className="h-3 w-16 bg-gray-200 rounded-md" />
-            <div className="h-3 w-20 bg-gray-200 rounded-md" />
+            <Skeleton size="sm" />
+            <Skeleton size="sm" />
           </div>
         </div>
       </div>

--- a/src/components/post/Skeleton/PostCardSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostCardSkeleton/index.tsx
@@ -1,35 +1,37 @@
 'use client'
 
+import { Skeleton } from '@/components/common'
+
 export default function PostCardSkeleton() {
   return (
     <div className="bg-white rounded-2xl p-6 shadow-sm border border-border animate-pulse">
       <div className="flex gap-4">
-        <div className="w-[188px] h-[188px] rounded-2xl bg-bg-disabled" />
+        <Skeleton className="w-[188px] h-[188px] rounded-2xl " />
         <div className="flex-1 ml-3">
           <div className="flex gap-2 mb-2">
             {[1, 2, 3].map((num) => (
-              <div key={num} className="h-6 w-12 bg-bg-disabled rounded-full" />
+              <Skeleton key={num} className="h-6 w-12" />
             ))}
           </div>
 
-          <div className="h-6 w-3/4 bg-bg-disabled rounded-md mb-2" />
+          <Skeleton className=" rounded-md mb-2" />
 
           <div className="flex gap-2 mb-3">
-            <div className="h-4 w-10 bg-bg-disabled rounded-md" />
-            <div className="h-4 w-16 bg-bg-disabled rounded-md" />
+            <Skeleton className="h-4 w-10 rounded-md" />
+            <Skeleton className="h-4 w-16 rounded-md" />
           </div>
 
           <div className="flex gap-2 flex-wrap mt-8">
             {[1, 2, 3, 4].map((num) => (
-              <div key={num} className="h-4 w-20 bg-bg-disabled rounded-md" />
+              <Skeleton key={num} size="sm" />
             ))}
           </div>
         </div>
 
         <div className="flex flex-col items-end justify-between">
-          <div className="w-10 h-10 rounded-full bg-bg-disabled" />
+          <Skeleton size="circle" />
 
-          <div className="w-24 h-8 bg-bg-disabled rounded-md" />
+          <Skeleton className="w-24 h-10  rounded-md" />
         </div>
       </div>
     </div>

--- a/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
+++ b/src/components/post/Skeleton/PostDetailSkeleton/index.tsx
@@ -1,66 +1,78 @@
 'use client'
 
+import { Skeleton } from '@/components/common'
+
 import CommentSkeleton from '../CommentSkeleton'
 
 export default function PostDetailSkeleton() {
   return (
     <div className="min-h-screen bg-bg-base py-8 px-4 flex justify-center">
-      <div className="max-w-7xl w-full bg-bg-base rounded-lg p-8 border border-[#DDDDDD] animate-pulse space-y-8">
-        {/* 제목 */}
+      <div className="max-w-7xl w-full bg-bg-base rounded-lg p-8 border border-[#DDDDDD]  space-y-8">
         <div className="space-y-3">
-          <div className="h-7 w-50 bg-bg-disabled rounded-md" />
+          {/* 제목 */}
+          <Skeleton />
           <div className="flex gap-2"></div>
         </div>
-        {/* 태그 */}
+        {/* 이미지 */}
         <div className="flex gap-3 mb-6">
           {[1, 2, 3].map((num) => (
-            <div key={num} className="w-32 h-32 bg-bg-disabled rounded-xl" />
+            <Skeleton key={num} className="w-32 h-32" />
           ))}
         </div>
-        {/* 이미지 */}
-        <div className="h-4 w-20 bg-bg-disabled rounded-md" />
+        {/* 태그 */}
+        <Skeleton size="sm" />
         <div className="flex gap-2">
           {[1, 2, 3].map((num) => (
-            <div key={num} className="h-6 w-14 bg-bg-disabled rounded-full" />
+            <Skeleton key={num} className=" w-14" />
           ))}
         </div>
-        {/* 지역 */}
+        {/* 국가 */}
         <div className="space-y-4">
-          <div className="h-4 w-30 bg-bg-disabled rounded-md" />
-          <div className="h-4 w-10 bg-bg-disabled rounded-md"></div>
+          <Skeleton />
+          <Skeleton size="sm" />
         </div>
         {/* 일정 */}
         <div>
-          <div className="h-4 w-30 bg-bg-disabled rounded-md mb-2" />
+          <Skeleton className=" mb-2" />
           <div className="grid grid-cols-2 gap-4 w-2/3">
-            <div className="h-8 w-full bg-bg-disabled rounded-md" />
-            <div className="h-8 w-full bg-bg-disabled rounded-md" />
+            <Skeleton size="lg" />
+            <Skeleton size="lg" />
           </div>
         </div>
         {/* 설명 */}
-        <div className="space-y-4">
-          <div className="h-4 w-30 bg-bg-disabled rounded-md" />
-          <div className="h-30 w-2/3 bg-bg-disabled rounded-md" />
+        <div className="space-y-4 w-2/3 ">
+          <Skeleton />
+          <Skeleton size="lg" className="h-30 " />
         </div>
         {/* 인원 및 조건 */}
-        <div className="h-4 w-30 bg-bg-disabled rounded-md" />
-        <div className="h-4 w-70 bg-bg-disabled rounded-md" />
+        <div>
+          <Skeleton className="mb-2" />
+          <Skeleton className="h-4 w-70 " />
+        </div>
         {/* 작성자 프로필 */}
-        <div className="h-6 w-36 bg-bg-disabled rounded-md" />
+        <Skeleton />
         <div className="space-y-3 border p-6 rounded-2xl">
-          <div className="flex gap-4">
-            <div className="w-16 h-16 rounded-full bg-bg-disabled" />
-            <div className="space-y-2">
-              <div className="h-4 w-20 bg-bg-disabled rounded-md" />
-              <div className="h-4 w-28 bg-bg-disabled rounded-md" />
-              <div className="h-4 w-24 bg-bg-disabled rounded-md" />
+          <div className="flex gap-2">
+            <Skeleton className="w-16 h-16 rounded-full" />
+            <Skeleton size="sm" className="mr-20 mt-4" />
+            <div className="flex gap-60">
+              <div className="space-y-2">
+                <Skeleton />
+                <Skeleton />
+                <Skeleton />
+              </div>
+              <div className="space-y-2">
+                <Skeleton />
+                <Skeleton />
+                <Skeleton />
+              </div>
             </div>
           </div>
         </div>
         {/* 버튼 */}
         <div className="flex gap-3 items-center justify-center my-8">
-          <div className="h-10 w-68 bg-bg-disabled rounded-md" />
-          <div className="h-10 w-68 bg-bg-disabled rounded-md" />
+          <Skeleton className="h-10 w-68" />
+          <Skeleton className="h-10 w-68" />
         </div>
         <CommentSkeleton />
       </div>

--- a/src/components/post/Skeleton/index.ts
+++ b/src/components/post/Skeleton/index.ts
@@ -1,3 +1,0 @@
-export { default as PostListSkeleton } from './PostListSkeleton'
-export { default as PostCardSkeleton } from './PostCardSkeleton'
-export { default as PostDetailSkeleton } from './PostDetailSkeleton'

--- a/src/components/post/index.ts
+++ b/src/components/post/index.ts
@@ -1,3 +1,5 @@
 export { default as PostList } from './List'
 export { default as PostForm } from './Form'
 export { default as PostDetail } from './Detail/PostDetail'
+export { default as PostListSkeleton } from './Skeleton/PostListSkeleton'
+export { default as PostDetailSkeleton } from './Skeleton/PostDetailSkeleton'

--- a/src/constants/posts/rule.const.ts
+++ b/src/constants/posts/rule.const.ts
@@ -11,17 +11,16 @@ export const REGION_OPTIONS = [
   '인도네시아',
 ] as const
 
-export const AGE_OPTIONS = Array.from({ length: 41 }, (_, i) => 20 + i)
+export const AGE_OPTIONS = [
+  { value: '20', label: '20대' },
+  { value: '30', label: '30대' },
+  { value: '40', label: '40대' },
 
-export const GENDER_OPTIONS = [
-  { value: '', label: '전체' },
-  { value: 'MALE', label: '남성만' },
-  { value: 'FEMALE', label: '여성만' },
-  { value: 'ALL', label: '무관' },
+  { value: 'ALL', label: '전체' },
 ] as const
 
-export const AGE_TYPE_OPTIONS = [
-  { value: '', label: '전체' },
-  { value: 'OLDER', label: '이상' },
-  { value: 'YOUNGER', label: '이하' },
+export const GENDER_OPTIONS = [
+  { value: 'MALE', label: '남성만' },
+  { value: 'FEMALE', label: '여성만' },
+  { value: 'ALL', label: '전체' },
 ] as const

--- a/src/constants/posts/rule.const.ts
+++ b/src/constants/posts/rule.const.ts
@@ -15,8 +15,6 @@ export const AGE_OPTIONS = [
   { value: '20', label: '20대' },
   { value: '30', label: '30대' },
   { value: '40', label: '40대' },
-
-  { value: 'ALL', label: '전체' },
 ] as const
 
 export const GENDER_OPTIONS = [

--- a/src/constants/posts/rule.const.ts
+++ b/src/constants/posts/rule.const.ts
@@ -12,12 +12,15 @@ export const REGION_OPTIONS = [
 ] as const
 
 export const AGE_OPTIONS = [
-  { value: '20', label: '20대' },
-  { value: '30', label: '30대' },
-  { value: '40', label: '40대' },
+  { value: 'TWENTY', label: '20대' },
+  { value: 'THIRTY', label: '30대' },
+  { value: 'FORTY', label: '40대' },
+  { value: 'FIFTY', label: '50대' },
+  { value: 'ETC', label: '모두' },
 ] as const
 
 export const GENDER_OPTIONS = [
   { value: 'MALE', label: '남성만' },
   { value: 'FEMALE', label: '여성만' },
+  { value: 'ALL', label: '모두' },
 ] as const

--- a/src/constants/posts/rule.const.ts
+++ b/src/constants/posts/rule.const.ts
@@ -20,5 +20,4 @@ export const AGE_OPTIONS = [
 export const GENDER_OPTIONS = [
   { value: 'MALE', label: '남성만' },
   { value: 'FEMALE', label: '여성만' },
-  { value: 'ALL', label: '전체' },
 ] as const

--- a/src/mocks/handlers/posts.ts
+++ b/src/mocks/handlers/posts.ts
@@ -55,7 +55,7 @@ export const postsHandlers = [
       endDate: string
     }
 
-    if (body.endDate > body.startDate) {
+    if (body.startDate > body.endDate) {
       return HttpResponse.json(
         {
           success: false,

--- a/src/types/posts/content.type.ts
+++ b/src/types/posts/content.type.ts
@@ -1,5 +1,5 @@
-export type GenderType = 'MALE' | 'FEMALE' | 'ALL' | ''
-export type AgeType = 'OLDER' | 'YOUNGER' | ''
+export type GenderType = 'MALE' | 'FEMALE' | 'ALL'
+export type AgeType = 'TWENTY' | 'THIRTY' | 'FOURTY' | 'FIFTY' | 'ETC'
 
 export interface Period {
   startDate: string
@@ -9,6 +9,7 @@ export interface Period {
 export interface PostContent {
   postId: string
   title: string
+  content: string
   region: string
   period: Period
   recruitStatus: 'RECRUITING' | 'CLOSED'
@@ -17,12 +18,11 @@ export interface PostContent {
   currentMembers: number
   maxMembers: number
   conditions: {
-    ageCondition: string
-    birthYear: number
-    genderCondition: string
+    ageCondition: AgeType
+    genderCondition: GenderType
   }
-  bookmarked: boolean
-  thumbnail: string
+  isBookmarked: boolean
+  thumbnail: string[]
   createdAt: string
   updatedAt: string
 }

--- a/src/types/posts/content.type.ts
+++ b/src/types/posts/content.type.ts
@@ -10,6 +10,7 @@ export interface PostContent {
   postId: string
   title: string
   content: string
+  nation: string
   region: string
   period: Period
   recruitStatus: 'RECRUITING' | 'CLOSED'

--- a/src/types/posts/request.type.ts
+++ b/src/types/posts/request.type.ts
@@ -1,11 +1,11 @@
 import { AgeType, GenderType } from './content.type'
 
 export interface PostParams {
-  region: string
-  date: string
-  ageType: AgeType
-  gender: GenderType
-  keyword: string
+  region?: string
+  date?: string
+  ageType?: AgeType
+  gender?: GenderType
+  keyword?: string
 }
 export interface PostApiParams {
   region?: string

--- a/src/types/posts/request.type.ts
+++ b/src/types/posts/request.type.ts
@@ -3,7 +3,6 @@ import { AgeType, GenderType } from './content.type'
 export interface PostParams {
   region: string
   date: string
-  age: string
   ageType: AgeType
   gender: GenderType
   keyword: string

--- a/src/types/posts/request.type.ts
+++ b/src/types/posts/request.type.ts
@@ -11,7 +11,6 @@ export interface PostParams {
 export interface PostApiParams {
   region?: string
   date?: string
-  age?: number
   ageType?: AgeType
   gender?: GenderType
   keyword?: string
@@ -29,6 +28,5 @@ export interface PostCreatePayload {
   tags: string[]
   images: string[]
   genderType: 'MALE' | 'FEMALE' | 'ALL'
-  birthYear: number
-  ageType: 'OLDER' | 'YOUNGER'
+  ageType: AgeType
 }

--- a/src/types/posts/request.type.ts
+++ b/src/types/posts/request.type.ts
@@ -1,14 +1,14 @@
 import { AgeType, GenderType } from './content.type'
 
 export interface PostParams {
-  region?: string
+  nation?: string
   date?: string
   ageType?: AgeType
   gender?: GenderType
   keyword?: string
 }
 export interface PostApiParams {
-  region?: string
+  nation?: string
   date?: string
   ageType?: AgeType
   gender?: GenderType
@@ -19,6 +19,7 @@ export interface PostApiParams {
 
 export interface PostCreatePayload {
   title: string
+  nation: string
   region: string
   startDate: string
   endDate: string


### PR DESCRIPTION
## 📌 이슈 넘버
> close #36 

## 📄 작업 페이지 및 내용 요약
> UI 전반 개선 — Skeleton 컴포넌트 추가 및 기존 폼 요소를 shadcn-ui 컴포넌트로 교체했습니다.

## 📝 작업 내용
> Skeleton 컴포넌트 신규 추가 (게시글 리스트/상세 등 적용)
 불필요한 스타일/컴포넌트 제거 및 코드 구조 정리
## 📷스크린샷
<img width="994" height="1250" alt="image" src="https://github.com/user-attachments/assets/c85c7fdf-3b85-4e80-ab74-40a0f609f89e" />

국가랑 나이랑 같은 열에 놨는데 어떤가요? 

