### PR TITLE
Feat(#59): 프로필수정 페이지 UI 개편

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "dayjs": "^1.11.19",
     "lucide-react": "^0.554.0",
     "motion": "^12.23.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19

--- a/src/app/member/edit/page.tsx
+++ b/src/app/member/edit/page.tsx
@@ -63,11 +63,9 @@ export default function ProfileEditPage() {
 
   return (
     <FormProvider {...methods}>
-      <div className="w-119 mx-auto ">
-        <h1 className="font-semibold text-[32px] text-center mb-12">
-          내 프로필
-        </h1>
-        <div className="flex justify-center mb-12">
+      <div className="w-119 mx-auto">
+        <h1 className="font-bold text-lg mb-6">프로필 수정</h1>
+        <div className="flex justify-center mb-6">
           <ProfileImageEdit />
         </div>
         <div className="w-inherit">

--- a/src/app/member/edit/page.tsx
+++ b/src/app/member/edit/page.tsx
@@ -15,6 +15,7 @@ export default function ProfileEditPage() {
   const methods = useForm<ProfileEditFormData>({
     resolver: zodResolver(profileEditSchema),
     defaultValues: {
+      email: '',
       image: '',
       nickname: '',
       birth: '',
@@ -29,6 +30,7 @@ export default function ProfileEditPage() {
   useEffect(() => {
     if (data) {
       methods.reset({
+        email: data.email || '',
         image: data.image || '',
         nickname: data.nickname || '',
         birth: data.birth || '',
@@ -57,16 +59,18 @@ export default function ProfileEditPage() {
     )
   }
 
+  console.log(data)
+
   return (
     <FormProvider {...methods}>
-      <div className="max-w-4xl mx-auto py-10 px-4">
+      <div className="max-w-119 mx-auto ">
         <h1 className="font-semibold text-[32px] text-center mb-12">
           내 프로필
         </h1>
         <div className="flex justify-center mb-12">
           <ProfileImageEdit />
         </div>
-        <div className="flex justify-center">
+        <div className="w-inherit">
           <ProfileEditForm />
         </div>
       </div>

--- a/src/app/member/edit/page.tsx
+++ b/src/app/member/edit/page.tsx
@@ -59,8 +59,6 @@ export default function ProfileEditPage() {
     )
   }
 
-  console.log(data)
-
   return (
     <FormProvider {...methods}>
       <div className="w-119 mx-auto">

--- a/src/app/member/edit/page.tsx
+++ b/src/app/member/edit/page.tsx
@@ -63,7 +63,7 @@ export default function ProfileEditPage() {
 
   return (
     <FormProvider {...methods}>
-      <div className="max-w-119 mx-auto ">
+      <div className="w-119 mx-auto ">
         <h1 className="font-semibold text-[32px] text-center mb-12">
           내 프로필
         </h1>

--- a/src/app/member/layout.tsx
+++ b/src/app/member/layout.tsx
@@ -12,7 +12,7 @@ export default function MemberLayout({
   const pathname = usePathname()
 
   if (pathname === '/member/edit') {
-    return <div className="max-w-7xl mx-auto mt-17">{children}</div>
+    return <div className="max-w-7xl mx-auto mt-10">{children}</div>
   }
 
   return (

--- a/src/components/form/FormTextarea/index.tsx
+++ b/src/components/form/FormTextarea/index.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { CircleAlert } from 'lucide-react'
+import { ComponentProps } from 'react'
+import {
+  FieldValues,
+  Path,
+  useController,
+  useFormContext,
+} from 'react-hook-form'
+
+import { Label } from '@/components/ui'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/common'
+
+interface Props<T extends FieldValues>
+  extends Omit<ComponentProps<'textarea'>, 'name'> {
+  label: string
+  name: Path<T>
+  rightContent?: string
+}
+
+export default function FormTextarea<T extends FieldValues>({
+  label,
+  name,
+  className,
+  rightContent,
+  required,
+  ...props
+}: Props<T>) {
+  const { control } = useFormContext<T>()
+
+  const {
+    field,
+    fieldState: { error },
+  } = useController({ name, control })
+
+  const isError = !!error
+
+  return (
+    <div className={cn('space-y-2 w-full')}>
+      <Label htmlFor={name} className="gap-1">
+        {label}
+        {required && <span className="text-destructive">*</span>}
+      </Label>
+      <div className="space-y-1 w-full">
+        <Textarea
+          aria-invalid={isError ? 'true' : 'false'}
+          id={name}
+          required={required}
+          className={className}
+          {...field}
+          {...props}
+        />
+        <div className="flex items-center justify-between">
+          <p className="h-6 flex text-xs text-danger items-center gap-1 px-4">
+            {isError && <CircleAlert className="size-4" />}
+            {error?.message}
+          </p>
+          {rightContent && <p className="text-main px-4">{rightContent}</p>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/member/edit/BasicInfo/index.tsx
+++ b/src/components/member/edit/BasicInfo/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AxiosError } from 'axios'
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
 
 import { useCheckNickname } from '@/api/member'
@@ -15,8 +15,12 @@ import { ApiResponse } from '@/types/common'
 import { ProfileEditFormData } from '@/types/member/schema'
 
 export default function BasicInfo() {
-  const { watch } = useFormContext<ProfileEditFormData>()
-  const nickname = watch('nickname')
+  const { control } = useFormContext<ProfileEditFormData>()
+
+  const nickname = useWatch({
+    control,
+    name: 'nickname',
+  })
 
   const { mutate: checkNickname, isPending } = useCheckNickname()
 
@@ -46,7 +50,7 @@ export default function BasicInfo() {
   }
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="w-inherit">
       <FormInput
         label="닉네임"
         name="nickname"
@@ -54,14 +58,14 @@ export default function BasicInfo() {
         placeholder="닉네임"
         maxLength={NICKNAME_MAX_LENGTH}
         required
-        className="w-100"
+        className=""
         rightElement={
           <Button
             type="button"
             onClick={handleCheckDuplicate}
             disabled={isPending || !nickname}
             variant="secondary"
-            size="sm"
+            size="md"
             className="whitespace-nowrap"
           >
             {isPending ? '확인 중' : '중복확인'}

--- a/src/components/member/edit/BioField/index.tsx
+++ b/src/components/member/edit/BioField/index.tsx
@@ -1,47 +1,16 @@
 'use client'
 
-import { useFormContext } from 'react-hook-form'
-
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { ProfileEditFormData } from '@/types/member/schema'
-
-const MAX_INTRODUCTION_LENGTH = 100
+import FormTextarea from '@/components/form/FormTextarea'
 
 export default function BioField() {
-  const {
-    register,
-    watch,
-    formState: { errors },
-  } = useFormContext<ProfileEditFormData>()
-
-  const introduction = watch('introduction') ?? ''
-  const length = introduction.length
-
   return (
     <div className="mt-6 flex flex-col gap-3">
-      <Label htmlFor="introduction">
-        자기소개
-        <span
-          className={`transition-colors ml-1.5 ${
-            length > 90 ? 'text-danger' : 'text-main'
-          }`}
-        >
-          {length}
-        </span>
-        /{MAX_INTRODUCTION_LENGTH}
-      </Label>
-      <Input
-        id="introduction"
-        {...register('introduction')}
-        type="text"
-        placeholder={`자기소개를 입력해주세요`}
-        maxLength={MAX_INTRODUCTION_LENGTH}
-        aria-invalid={!!errors.introduction}
+      <FormTextarea
+        label="자기소개"
+        name="introduction"
+        placeholder="자기소개를 입력해주세요"
+        className="resize-none min-h-30"
       />
-      {errors.introduction && (
-        <p className="text-danger text-sm">{errors.introduction.message}</p>
-      )}
     </div>
   )
 }

--- a/src/components/member/edit/BirthdayAndMbti/index.tsx
+++ b/src/components/member/edit/BirthdayAndMbti/index.tsx
@@ -17,33 +17,23 @@ const MBTI_OPTIONS = [
   })),
 ]
 export default function BirthdayAndMbti() {
-  const {
-    watch,
-    formState: { errors },
-  } = useFormContext<ProfileEditFormData>()
+  const { watch } = useFormContext<ProfileEditFormData>()
 
   const mbti = watch('mbti')
 
   return (
-    <div className="flex mt-6 gap-6">
-      <div className="flex flex-col gap-3">
-        <Label>
-          생일 <span className="text-danger">*</span>
-        </Label>
+    <div className="flex mt-6 gap-4">
+      <div className="flex-1">
         <BirthdaySelect />
-        {errors.birth && (
-          <p className="text-danger text-sm">{errors.birth.message}</p>
-        )}
       </div>
-
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 flex-1">
         <Label htmlFor="mbti">MBTI</Label>
         <FormSelect
           key={`mbti-${mbti}`}
           name="mbti"
+          className="w-full"
           options={MBTI_OPTIONS}
-          placeholder="MBTI"
-          className="w-42"
+          placeholder="MBTI를 선택해주세요"
         />
       </div>
     </div>

--- a/src/components/member/edit/BirthdayAndMbti/index.tsx
+++ b/src/components/member/edit/BirthdayAndMbti/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 
 import { FormSelect } from '@/components/form'
 import { Label } from '@/components/ui/label'
@@ -17,9 +17,12 @@ const MBTI_OPTIONS = [
   })),
 ]
 export default function BirthdayAndMbti() {
-  const { watch } = useFormContext<ProfileEditFormData>()
+  const { control } = useFormContext<ProfileEditFormData>()
 
-  const mbti = watch('mbti')
+  const mbti = useWatch({
+    control,
+    name: 'mbti',
+  })
 
   return (
     <div className="flex mt-6 gap-4">

--- a/src/components/member/edit/BirthdaySelect/index.tsx
+++ b/src/components/member/edit/BirthdaySelect/index.tsx
@@ -1,156 +1,54 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useFormContext } from 'react-hook-form'
+import { ko } from 'date-fns/locale'
+import { Calendar as CalendarIcon } from 'lucide-react'
+import DatePicker from 'react-datepicker'
+import { Controller, useFormContext } from 'react-hook-form'
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
+import { Label } from '@/components/ui/label'
 import { ProfileEditFormData } from '@/types/member/schema'
 
-const years = Array.from(
-  { length: 100 },
-  (_, i) => new Date().getFullYear() - i,
-)
-const months = Array.from({ length: 12 }, (_, i) => i + 1)
+import 'react-datepicker/dist/react-datepicker.css'
 
 export default function BirthdaySelect() {
-  const { setValue, watch } = useFormContext<ProfileEditFormData>()
-  const birthValue = watch('birth')
-
-  const parseBirthDate = (birth: string) => {
-    if (!birth || birth === '') {
-      return { year: '', month: '', day: '' }
-    }
-    const [y, m, d] = birth.split('-')
-    const monthNum = parseInt(m)
-    const dayNum = parseInt(d)
-
-    return {
-      year: y || '',
-      month: !isNaN(monthNum) ? String(monthNum) : '',
-      day: !isNaN(dayNum) ? String(dayNum) : '',
-    }
-  }
-
-  const [selected, setSelected] = useState({ year: '', month: '', day: '' })
-
-  useEffect(() => {
-    const syncBirthValue = () => {
-      const current = parseBirthDate(birthValue)
-      setSelected(current)
-    }
-    syncBirthValue()
-  }, [birthValue])
-
-  const getDaysInMonth = (y: string, m: string) => {
-    const year = parseInt(y)
-    const month = parseInt(m)
-    if (!year || !month || isNaN(year) || isNaN(month)) return []
-    return Array.from(
-      { length: new Date(year, month, 0).getDate() },
-      (_, i) => i + 1,
-    )
-  }
-
-  const days = getDaysInMonth(selected.year, selected.month)
-
-  const handleYearChange = (year: string) => {
-    if (year === 'none') {
-      setSelected({ year: '', month: '', day: '' })
-      setValue('birth', '', { shouldDirty: true })
-    } else {
-      setSelected({ year, month: '', day: '' })
-    }
-  }
-
-  const handleMonthChange = (month: string) => {
-    if (month === 'none') {
-      setSelected((prev) => ({ ...prev, month: '', day: '' }))
-      setValue('birth', '', { shouldDirty: true })
-    } else {
-      setSelected((prev) => ({ ...prev, month, day: '' }))
-    }
-  }
-
-  const handleDayChange = (day: string) => {
-    if (day === 'none') {
-      setSelected((prev) => ({ ...prev, day: '' }))
-      setValue('birth', '', { shouldDirty: true })
-    } else {
-      const year = parseInt(selected.year)
-      const month = parseInt(selected.month)
-      const dayNum = parseInt(day)
-
-      if (!isNaN(year) && !isNaN(month) && !isNaN(dayNum)) {
-        const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`
-        setSelected((prev) => ({ ...prev, day }))
-        setValue('birth', dateStr, { shouldDirty: true })
-      }
-    }
-  }
+  const { control } = useFormContext<ProfileEditFormData>()
 
   return (
-    <div className="flex gap-3">
-      <Select
-        key={`year-${selected.year}`}
-        value={selected.year || 'none'}
-        onValueChange={handleYearChange}
-      >
-        <SelectTrigger className="min-w-[135px]">
-          <SelectValue placeholder="년" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="none">년</SelectItem>
-          {years.map((y) => (
-            <SelectItem key={y} value={String(y)}>
-              {y}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      <Select
-        key={`month-${selected.month}`}
-        value={selected.month || 'none'}
-        onValueChange={handleMonthChange}
-        disabled={!selected.year}
-      >
-        <SelectTrigger className="min-w-25">
-          <SelectValue placeholder="월" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="none">월</SelectItem>
-          {months.map((m) => (
-            <SelectItem key={m} value={String(m)}>
-              {m}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      <Select
-        key={`day-${selected.day}`}
-        value={selected.day || 'none'}
-        onValueChange={handleDayChange}
-        disabled={!selected.year || !selected.month}
-      >
-        <SelectTrigger className="min-w-25">
-          <SelectValue placeholder="일" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="none">일</SelectItem>
-          {days.map((d) => (
-            <SelectItem key={d} value={String(d)}>
-              {d}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div className="space-y-2">
+      <Label>생년월일</Label>
+      <Controller
+        name="birth"
+        control={control}
+        render={({ field }) => (
+          <div className="relative">
+            <DatePicker
+              selected={field.value ? new Date(field.value) : null}
+              onChange={(date: Date | null) => {
+                if (date) {
+                  const year = date.getFullYear()
+                  const month = String(date.getMonth() + 1).padStart(2, '0')
+                  const day = String(date.getDate()).padStart(2, '0')
+                  field.onChange(`${year}-${month}-${day}`)
+                } else {
+                  field.onChange('')
+                }
+              }}
+              locale={ko}
+              dateFormat="yyyy-MM-dd"
+              placeholderText="생년월일을 선택해주세요"
+              maxDate={new Date()}
+              minDate={new Date('1900-01-01')}
+              openToDate={new Date('2000-01-01')}
+              showMonthDropdown
+              showYearDropdown
+              dropdownMode="select"
+              yearDropdownItemNumber={100}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-base outline-none"
+            />
+            <CalendarIcon className="absolute right-3 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground pointer-events-none" />
+          </div>
+        )}
+      />
     </div>
   )
 }

--- a/src/components/member/edit/EmailField/index.tsx
+++ b/src/components/member/edit/EmailField/index.tsx
@@ -1,0 +1,5 @@
+import { FormInput } from '@/components/form'
+
+export default function EmailField() {
+  return <FormInput label="이메일" name="email" type="text" disabled={true} />
+}

--- a/src/components/member/edit/FormActionBtn/index.tsx
+++ b/src/components/member/edit/FormActionBtn/index.tsx
@@ -48,26 +48,26 @@ export default function FormActionBtn() {
   }
 
   return (
-    <div className="flex justify-center gap-7 my-20">
+    <div className="flex justify-center gap-4 mb-10">
       <Button
         type="button"
         variant="secondary"
         size="md"
-        className="w-[185px] text-lg font-extrabold"
+        className="flex-1 text-lg font-extrabold"
         onClick={() => {
           router.back()
         }}
       >
-        나가기
+        취소
       </Button>
       <Button
         type="button"
         size="md"
-        className="w-[185px] text-lg font-extrabold"
+        className="flex-1 text-lg font-extrabold"
         onClick={handleSubmit(onSubmit)}
         disabled={!isDirty || isLoading}
       >
-        프로필 수정하기
+        수정하기
       </Button>
     </div>
   )

--- a/src/components/member/edit/GenderField/index.tsx
+++ b/src/components/member/edit/GenderField/index.tsx
@@ -28,16 +28,16 @@ export default function GenderField() {
             aria-invalid={!!errors.gender}
           >
             <div className="flex items-center gap-3">
-              <Label htmlFor="gender-male" className="font-normal">
-                남
-              </Label>
               <RadioGroupItem id="gender-male" value="MALE" />
+              <Label htmlFor="gender-male" className="font-normal">
+                남성
+              </Label>
             </div>
             <div className="flex items-center gap-3">
-              <Label htmlFor="gender-female" className="font-normal">
-                여
-              </Label>
               <RadioGroupItem id="gender-female" value="FEMALE" />
+              <Label htmlFor="gender-female" className="font-normal">
+                여성
+              </Label>
             </div>
           </RadioGroup>
         )}

--- a/src/components/member/edit/PreferenceInfo/index.tsx
+++ b/src/components/member/edit/PreferenceInfo/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 
 import { FormSelect } from '@/components/form'
 import { Label } from '@/components/ui'
@@ -11,10 +11,17 @@ import {
 import { ProfileEditFormData } from '@/types/member/schema'
 
 export default function PreferenceInfo() {
-  const { watch } = useFormContext<ProfileEditFormData>()
+  const { control } = useFormContext<ProfileEditFormData>()
 
-  const lodgingStyle = watch('lodgingStyle')
-  const tripStyle = watch('tripStyle')
+  const lodgingStyle = useWatch({
+    control,
+    name: 'lodgingStyle',
+  })
+
+  const tripStyle = useWatch({
+    control,
+    name: 'tripStyle',
+  })
 
   return (
     <div className="flex mt-6 gap-6 w-inherit">

--- a/src/components/member/edit/PreferenceInfo/index.tsx
+++ b/src/components/member/edit/PreferenceInfo/index.tsx
@@ -17,18 +17,7 @@ export default function PreferenceInfo() {
   const tripStyle = watch('tripStyle')
 
   return (
-    <div className="flex mt-6 gap-6">
-      <div className="flex flex-col gap-3 flex-1">
-        <Label htmlFor="lodgingStyle">숙소 취향</Label>
-        <FormSelect
-          key={`lodgingStyle-${lodgingStyle}`}
-          name="lodgingStyle"
-          options={LODGING_STYLE_OPTIONS}
-          placeholder="숙소 취향을 선택해주세요"
-          className="w-66"
-        />
-      </div>
-
+    <div className="flex mt-6 gap-6 w-inherit">
       <div className="flex flex-col gap-3 flex-1">
         <Label htmlFor="tripStyle">여행 스타일</Label>
         <FormSelect
@@ -36,7 +25,17 @@ export default function PreferenceInfo() {
           name="tripStyle"
           options={TRIP_STYLE_OPTIONS}
           placeholder="여행 스타일을 선택해주세요"
-          className="w-66"
+          className="w-full"
+        />
+      </div>
+      <div className="flex flex-col gap-3 flex-1">
+        <Label htmlFor="lodgingStyle">숙소 취향</Label>
+        <FormSelect
+          key={`lodgingStyle-${lodgingStyle}`}
+          name="lodgingStyle"
+          options={LODGING_STYLE_OPTIONS}
+          placeholder="숙소 취향을 선택해주세요"
+          className="w-full"
         />
       </div>
     </div>

--- a/src/components/member/edit/ProfileEditForm/index.tsx
+++ b/src/components/member/edit/ProfileEditForm/index.tsx
@@ -1,17 +1,17 @@
 import BasicInfo from '../BasicInfo'
 import BioField from '../BioField'
 import BirthdayAndMbti from '../BirthdayAndMbti'
+import EmailField from '../EmailField'
 import FormActionBtn from '../FormActionBtn'
 import GenderField from '../GenderField'
 import PreferenceInfo from '../PreferenceInfo'
 
 export default function ProfileEditForm() {
   return (
-    <form action="" className="w-138">
-      <div className="flex gap-6">
-        <BasicInfo />
-        <GenderField />
-      </div>
+    <form action="" className="w-inherit">
+      <EmailField />
+      <BasicInfo />
+      <GenderField />
       <BirthdayAndMbti />
       <PreferenceInfo />
       <BioField />

--- a/src/components/member/edit/ProfileImageEdit/index.tsx
+++ b/src/components/member/edit/ProfileImageEdit/index.tsx
@@ -3,7 +3,7 @@
 import { Loader2, Pencil } from 'lucide-react'
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
 
 import { uploadMemberImage } from '@/api/images/images.client'
@@ -12,8 +12,12 @@ import { getImageUrl } from '@/lib/common'
 import { ProfileEditFormData } from '@/types/member/schema'
 
 export default function ProfileImageEdit() {
-  const { setValue, watch } = useFormContext<ProfileEditFormData>()
-  const imageValue = watch('image')
+  const { setValue, control } = useFormContext<ProfileEditFormData>()
+
+  const imageValue = useWatch({
+    control,
+    name: 'image',
+  })
 
   const [profileImg, setProfileImg] = useState<string | null>(null)
   const [isUploading, setIsUploading] = useState(false)

--- a/src/components/member/edit/ProfileImageEdit/index.tsx
+++ b/src/components/member/edit/ProfileImageEdit/index.tsx
@@ -108,7 +108,7 @@ export default function ProfileImageEdit() {
 
   return (
     <div className="relative group">
-      <div className="relative w-[173px] h-[173px] rounded-full overflow-hidden border-2 border-[#DDDDDD] bg-gray-50">
+      <div className="relative w-20 h-20 rounded-full overflow-hidden border-2 border-[#DDDDDD] bg-gray-50">
         <Image
           fill
           src={
@@ -131,9 +131,9 @@ export default function ProfileImageEdit() {
         type="button"
         onClick={handleEditClick}
         disabled={isUploading}
-        className="absolute bottom-0 right-0 w-12 h-12 bg-white rounded-full border-2 border-[#dddddd] flex items-center justify-center shadow-lg cursor-pointer transition-all hover:scale-110 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="absolute bottom-0 -right-2.5 w-8 h-8 bg-white rounded-full border-2 border-[#dddddd] flex items-center justify-center shadow-lg cursor-pointer transition-all hover:scale-110 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
       >
-        <Pencil size={24} className="text-gray-700" />
+        <Pencil size={18} className="text-gray-700" />
       </button>
 
       <input

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -14,7 +14,7 @@ function Textarea({
       placeholder={disabled ? undefined : placeholder}
       disabled={disabled}
       className={cn(
-        'placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-xl bg-input px-4 py-3 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground',
+        'placeholder:text-muted-foreground border border-gray-200 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-xl px-4 py-3 text-base transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground',
         className,
       )}
       {...props}

--- a/src/types/member/schema.ts
+++ b/src/types/member/schema.ts
@@ -1,8 +1,9 @@
-import { z } from 'zod'
+import { email, z } from 'zod'
 
 import { NICKNAME_MAX_LENGTH, NICKNAME_REGEX } from '@/constants/member'
 
 export const profileEditSchema = z.object({
+  email: email().optional(),
   image: z.string().optional(),
   nickname: z
     .string()

--- a/src/types/member/schema.ts
+++ b/src/types/member/schema.ts
@@ -1,9 +1,9 @@
-import { email, z } from 'zod'
+import { z } from 'zod'
 
 import { NICKNAME_MAX_LENGTH, NICKNAME_REGEX } from '@/constants/member'
 
 export const profileEditSchema = z.object({
-  email: email().optional(),
+  email: z.string().optional(),
   image: z.string().optional(),
   nickname: z
     .string()


### PR DESCRIPTION
## 📌 이슈 넘버
> #59 

## 📄 작업 페이지 및 내용 요약
> 프로필수정 페이지 UI 개편
프로필수정 페이지 렌더링최적화
FormTextarea 공통컴포넌트 제작
date-fns 라이브러리 설치

## 📝 작업 내용
>  프로필 수정페이지에서 새로나온 디자인으로 UI 개편작업 진행하였습니다.
프로필수정페이지의 컴포넌트중에 watch를 사용하던것을 useWatch로 전부 변경하였습니다.
이로 인해 불필요한 다른 컴포넌트의 렌더링을 없애고 렌더링 최적화하였습니다.
ui의 Textarea 컴포넌트를 이용하여 폼에서 사용가능한 FormTextarea 컴포넌트를 제작하고 사용하였습니다.
생일 선택 UI가 변경됨에 따라서 react-datepicker를 사용하였으며, 사용자 UI 선택부분에서 좀더 나은 환경을 위해서
월 선택부분에 기존 June 등 영어로 표기되던것을 5월,6월 등 한글로 표기하기위해 ko를 지원하는 date-fns 를 설치하였습니다. 

## 📸 스크린샷(선택)

<img width="601" height="896" alt="image" src="https://github.com/user-attachments/assets/5a814a4d-8150-4973-aead-ba04ffa00b7b" />


## 💬리뷰 요구사항(선택)
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

closes #59 
