### PR TITLE
Bug(#65): 프로필 이미지 변경시 png외 다른 이미지파일 업로드 안되는 버그

### DIFF
--- a/src/api/images/images.client.ts
+++ b/src/api/images/images.client.ts
@@ -50,7 +50,6 @@ export const uploadToS3 = async (
  */
 const getContentType = (imageType: string): string => {
   const typeMap: Record<string, string> = {
-    JPG: 'image/jpeg',
     JPEG: 'image/jpeg',
     PNG: 'image/png',
     WEBP: 'image/webp',

--- a/src/api/images/images.client.ts
+++ b/src/api/images/images.client.ts
@@ -26,12 +26,6 @@ export const uploadToS3 = async (
   file: File | Blob,
   contentType: string,
 ) => {
-  console.log('🔍 9. S3 PUT 요청:', {
-    contentType,
-    fileSize: file.size,
-    url: presignedUrl.substring(0, 50) + '...',
-  })
-
   try {
     const res = await fetch(presignedUrl, {
       method: 'PUT',
@@ -39,11 +33,6 @@ export const uploadToS3 = async (
       headers: {
         'Content-Type': contentType,
       },
-    })
-    console.log('🔍 10. S3 응답:', {
-      status: res.status,
-      statusText: res.statusText,
-      ok: res.ok,
     })
 
     if (!res.ok) {
@@ -115,11 +104,6 @@ export const uploadMemberImage = async (
   imageType: 'JPEG' | 'PNG' | 'WEBP', // ✅ 'JPG', 'SVG' 제거
   imageDirectory: 'MEMBER',
 ): Promise<string> => {
-  console.log('🔍 5. uploadMemberImage 호출:', {
-    imageType,
-    fileType: file.type,
-    fileSize: file.size,
-  })
   // 1. Presigned URL 발급
   const presignedData = await getPresignedUrl({
     images: [
@@ -131,19 +115,8 @@ export const uploadMemberImage = async (
     ],
   })
 
-  console.log('🔍 6. Presigned URL 발급 성공:', {
-    presignedUrl: presignedData[0].presignedUrl.substring(0, 50) + '...',
-    imagePath: presignedData[0].image,
-  })
-
   // 2. 실제 파일/Blob의 Content-Type 사용 (간소화) ✅
   const actualContentType = file.type || getContentType(imageType)
-
-  console.log('🔍 7. S3 업로드 시도:', {
-    contentType: actualContentType,
-    fileType: file.type,
-    fallbackType: getContentType(imageType),
-  })
 
   // 3. S3 업로드
   const { presignedUrl, image } = presignedData[0]

--- a/src/api/images/images.client.ts
+++ b/src/api/images/images.client.ts
@@ -26,6 +26,12 @@ export const uploadToS3 = async (
   file: File | Blob,
   contentType: string,
 ) => {
+  console.log('🔍 9. S3 PUT 요청:', {
+    contentType,
+    fileSize: file.size,
+    url: presignedUrl.substring(0, 50) + '...',
+  })
+
   try {
     const res = await fetch(presignedUrl, {
       method: 'PUT',
@@ -33,6 +39,11 @@ export const uploadToS3 = async (
       headers: {
         'Content-Type': contentType,
       },
+    })
+    console.log('🔍 10. S3 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+      ok: res.ok,
     })
 
     if (!res.ok) {
@@ -53,7 +64,7 @@ const getContentType = (imageType: string): string => {
     JPG: 'image/jpeg',
     JPEG: 'image/jpeg',
     PNG: 'image/png',
-    SVG: 'image/svg+xml',
+    WEBP: 'image/webp',
   }
   return typeMap[imageType] || 'image/jpeg'
 }
@@ -61,11 +72,11 @@ const getContentType = (imageType: string): string => {
 /**
  * 파일에서 이미지 타입 추출
  */
-const getImageTypeFromFile = (file: File): 'JPG' | 'JPEG' | 'PNG' | 'SVG' => {
-  const fileType = file.type.split('/')[1]?.toUpperCase() || 'JPG'
+const getImageTypeFromFile = (file: File): 'JPEG' | 'PNG' | 'WEBP' => {
+  const fileType = file.type.split('/')[1]?.toUpperCase() || 'JPEG'
   if (fileType === 'JPEG' || fileType === 'JPG') return 'JPEG'
   if (fileType === 'PNG') return 'PNG'
-  if (fileType === 'SVG+XML' || fileType === 'SVG') return 'SVG'
+  if (fileType === 'WEBP') return 'WEBP'
   return 'JPEG'
 }
 
@@ -101,9 +112,15 @@ export const uploadPostImages = async (
 
 export const uploadMemberImage = async (
   file: File | Blob,
-  imageType: 'JPG' | 'JPEG' | 'PNG' | 'SVG',
+  imageType: 'JPEG' | 'PNG' | 'WEBP', // ✅ 'JPG', 'SVG' 제거
   imageDirectory: 'MEMBER',
 ): Promise<string> => {
+  console.log('🔍 5. uploadMemberImage 호출:', {
+    imageType,
+    fileType: file.type,
+    fileSize: file.size,
+  })
+  // 1. Presigned URL 발급
   const presignedData = await getPresignedUrl({
     images: [
       {
@@ -114,13 +131,28 @@ export const uploadMemberImage = async (
     ],
   })
 
-  // 2. S3 업로드
-  const { presignedUrl, image } = presignedData[0]
-  await uploadToS3(presignedUrl, file, getContentType(imageType))
+  console.log('🔍 6. Presigned URL 발급 성공:', {
+    presignedUrl: presignedData[0].presignedUrl.substring(0, 50) + '...',
+    imagePath: presignedData[0].image,
+  })
 
-  // 3. 이미지 경로 반환
+  // 2. 실제 파일/Blob의 Content-Type 사용 (간소화) ✅
+  const actualContentType = file.type || getContentType(imageType)
+
+  console.log('🔍 7. S3 업로드 시도:', {
+    contentType: actualContentType,
+    fileType: file.type,
+    fallbackType: getContentType(imageType),
+  })
+
+  // 3. S3 업로드
+  const { presignedUrl, image } = presignedData[0]
+  await uploadToS3(presignedUrl, file, actualContentType)
+
+  // 4. 이미지 경로 반환
   return image
 }
+
 export const deleteUnusedImage = async (imagePath: string): Promise<void> => {
   await axios.delete(`/api/images/${encodeURIComponent(imagePath)}`)
 }

--- a/src/components/member/edit/ProfileImageEdit/index.tsx
+++ b/src/components/member/edit/ProfileImageEdit/index.tsx
@@ -131,7 +131,7 @@ export default function ProfileImageEdit() {
 
       <input
         type="file"
-        accept="image/jpeg,image/jpg,image/png,image/svg+xml,image/webp"
+        accept="image/jpeg,image/jpg,image/png,image/webp"
         ref={fileInputRef}
         onChange={handleFileChange}
         className="hidden"

--- a/src/components/member/edit/ProfileImageEdit/index.tsx
+++ b/src/components/member/edit/ProfileImageEdit/index.tsx
@@ -48,18 +48,18 @@ export default function ProfileImageEdit() {
   /**
    * 파일 확장자를 기반으로 이미지 타입 추출
    */
-  const getImageType = (file: File): 'JPG' | 'PNG' | 'SVG' | null => {
-    const extension = file.name.split('.').pop()?.toUpperCase()
-    if (extension === 'JPG' || extension === 'JPEG') return 'JPG'
-    if (extension === 'PNG') return 'PNG'
-    if (extension === 'SVG') return 'SVG'
+  const getImageType = (file: File): 'JPEG' | 'PNG' | 'WEBP' | null => {
+    const mimeType = file.type.split('/')[1]?.toUpperCase()
+    if (mimeType === 'JPEG') return 'JPEG'
+    if (mimeType === 'PNG') return 'PNG'
+    if (mimeType === 'WEBP') return 'WEBP'
     return null
   }
 
   /**
    * 이미지 파일 선택 및 업로드 처리
    * 1. 파일 타입 검증
-   * 2. 이미지 압축 (SVG 제외)
+   * 2. 이미지 압축
    * 3. S3 업로드
    * 4. 폼 상태 업데이트
    */
@@ -67,10 +67,10 @@ export default function ProfileImageEdit() {
     const file = e.target.files?.[0]
     if (!file) return
 
-    // 이미지 타입 검증
     const imageType = getImageType(file)
+
     if (!imageType) {
-      toast.error('JPG, JPEG, PNG, SVG만 업로드 가능해요!')
+      toast.error('JPG, JPEG, PNG, WEBP만 업로드 가능해요!')
       e.target.value = ''
       return
     }
@@ -78,30 +78,19 @@ export default function ProfileImageEdit() {
     try {
       setIsUploading(true)
 
-      let uploadFile: File | Blob = file
-      let previewUrl: string
-
-      // SVG는 압축하지 않고 그대로 사용
-      if (imageType === 'SVG') {
-        uploadFile = file
-        previewUrl = URL.createObjectURL(file)
-      } else {
-        // JPG, PNG는 압축 처리
-        const compressed = await compress(file)
-        uploadFile = compressed.file
-        previewUrl = compressed.previewUrl
-      }
+      // 이미지 압축 처리
+      const compressed = await compress(file)
+      const uploadFile = compressed.file
+      const previewUrl = compressed.previewUrl
 
       // 프리뷰 이미지 즉시 표시
       setProfileImg(previewUrl)
 
-      //프리사인드 됐으면 S3 업로드할부분
       const imagePath = await uploadMemberImage(uploadFile, imageType, 'MEMBER')
       setValue('image', imagePath, { shouldDirty: true })
 
       toast.success('프로필 사진이 변경되었습니다!', { duration: 2000 })
     } catch (err) {
-      // 업로드 실패 시 원본 이미지로 복구
       setProfileImg(imageValue || null)
       toast.error('이미지 업로드 중 오류가 발생했습니다')
     } finally {
@@ -142,7 +131,7 @@ export default function ProfileImageEdit() {
 
       <input
         type="file"
-        accept="image/jpeg,image/jpg,image/png,image/svg+xml"
+        accept="image/jpeg,image/jpg,image/png,image/svg+xml,image/webp"
         ref={fileInputRef}
         onChange={handleFileChange}
         className="hidden"

--- a/src/types/member/type.ts
+++ b/src/types/member/type.ts
@@ -41,7 +41,7 @@ export interface MyProfile {
 export interface PresignedUrlRequest {
   images: Array<{
     imageId: string
-    imageType: 'JPG' | 'JPEG' | 'PNG' | 'SVG'
+    imageType: 'JPG' | 'JPEG' | 'PNG' | 'WEBP'
     imageDirectory: 'MEMBER' | 'POST'
   }>
 }


### PR DESCRIPTION
## 📌 이슈 넘버
> #65 

## 📄 작업 페이지 및 내용 요약
> 이미지 업로드 문제 수정하였습니다.
업로드 가능한 파일 확장자 타입변경

## 📝 작업 내용
> 프로필 이미지 업로드 시 Presigned URL 요청 단계에서는 
파일 확장자 기반으로 'JPG'를 전송했지만, 
실제 S3 업로드 단계에서는 브라우저의 MIME type인 'image/jpeg'를 
Content-Type으로 사용하여 불일치가 발생했습니다
이를 해결하기 위해 파일 확장자 대신 MIME type 기반으로 
이미지 타입을 판단하도록 수정하여 두 단계 모두 'JPEG'로 
통일함으로써 문제를 해결했습니다.

> 그리고 SVG 파일이 업로드 안되던문제가 있는데 이건 초기 백엔드와 협의에 따라 WEBP 로 수정완료하였습니다.
현재 업로드 가능한 파일 확장자는 JPG, JPEG, WEBP, PNG 이렇게 4종료이고, SVG는 제외입니다.

>Post쪽 업로드 로직도 SVG에서 WEBP로 같이 변경해놓았습니다.


## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

closes #65 
