### PR TITLE
Refacto(#69):이미지 압축 훅 용도별 설정 분리 작업

### DIFF
--- a/src/components/member/edit/ProfileImageEdit/index.tsx
+++ b/src/components/member/edit/ProfileImageEdit/index.tsx
@@ -22,7 +22,7 @@ export default function ProfileImageEdit() {
   const [profileImg, setProfileImg] = useState<string | null>(null)
   const [isUploading, setIsUploading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const { compress } = useImageCompress()
+  const { compress } = useImageCompress('profile')
 
   // 폼의 image 값이 변경되면 프로필 이미지 상태 업데이트
   useEffect(() => {

--- a/src/hooks/member/useImageCompress.ts
+++ b/src/hooks/member/useImageCompress.ts
@@ -11,10 +11,10 @@ const COMPRESSION_PRESETS: Record<PresetType, Options> = {
     initialQuality: 0.85,
   },
   post: {
-    maxSizeMB: 2,
+    maxSizeMB: 1.5,
     maxWidthOrHeight: 1920,
     useWebWorker: true,
-    initialQuality: 0.9,
+    initialQuality: 0.85,
   },
 }
 

--- a/src/hooks/member/useImageCompress.ts
+++ b/src/hooks/member/useImageCompress.ts
@@ -1,6 +1,23 @@
 import imageCompression, { Options } from 'browser-image-compression'
 import { useState } from 'react'
 
+type PresetType = 'profile' | 'post'
+
+const COMPRESSION_PRESETS: Record<PresetType, Options> = {
+  profile: {
+    maxSizeMB: 0.5,
+    maxWidthOrHeight: 512,
+    useWebWorker: true,
+    initialQuality: 0.85,
+  },
+  post: {
+    maxSizeMB: 2,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+    initialQuality: 0.9,
+  },
+}
+
 interface CompressResult {
   file: File
   previewUrl: string
@@ -18,6 +35,7 @@ interface UseImageCompressReturn {
 }
 
 export default function useImageCompress(
+  preset: PresetType = 'profile',
   customOptions?: Partial<Options>,
 ): UseImageCompressReturn {
   const [isCompressing, setIsCompressing] = useState(false)
@@ -36,10 +54,7 @@ export default function useImageCompress(
 
     try {
       const options: Options = {
-        maxSizeMB: 0.5,
-        maxWidthOrHeight: 512,
-        useWebWorker: true,
-        initialQuality: 0.85,
+        ...COMPRESSION_PRESETS[preset],
         ...customOptions,
       }
 


### PR DESCRIPTION
## 📌 이슈 넘버
> #69 

## 📄 작업 페이지 및 내용 요약
> 이미지 훅 프리셋 추가

## 📝 작업 내용
이미지 압축 훅에 프리셋 기능을 추가하여 용도별로 다른 압축 설정을 사용할 수 있도록 개선했습니다.
- `profile`: 512px, 0.5MB 
- `post`: 1920px, 1.5MB 
### 사용 예시
```typescript
프로필 이미지
const { compress } = useImageCompress('profile')

게시글 이미지  
const { compress } = useImageCompress('post')
```
테스트 완료했습니다.

closes #69 
