### PR TITLE
Refactor(#85):이미지압축 훅 개선작업

### DIFF
--- a/src/hooks/member/useImageCompress.ts
+++ b/src/hooks/member/useImageCompress.ts
@@ -5,16 +5,18 @@ type PresetType = 'profile' | 'post'
 
 const COMPRESSION_PRESETS: Record<PresetType, Options> = {
   profile: {
-    maxSizeMB: 0.5,
-    maxWidthOrHeight: 512,
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1024,
     useWebWorker: true,
-    initialQuality: 0.85,
+    initialQuality: 0.9,
+    alwaysKeepResolution: false,
   },
   post: {
-    maxSizeMB: 1.5,
+    maxSizeMB: 3,
     maxWidthOrHeight: 1920,
     useWebWorker: true,
-    initialQuality: 0.85,
+    initialQuality: 0.9,
+    alwaysKeepResolution: false,
   },
 }
 
@@ -60,15 +62,26 @@ export default function useImageCompress(
 
       const compressedFile = await imageCompression(file, options)
 
-      const preview = URL.createObjectURL(compressedFile)
-      setPreviewUrl(preview)
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl)
+      }
+
+      const newPreviewUrl = URL.createObjectURL(compressedFile)
+      setPreviewUrl(newPreviewUrl)
+
+      const originalSize = file.size
+      const compressedSize = compressedFile.size
+      const ratio =
+        originalSize > 0
+          ? Number(((1 - compressedSize / originalSize) * 100).toFixed(1))
+          : 0
 
       const result: CompressResult = {
         file: compressedFile,
-        previewUrl: preview,
-        originalSize: file.size,
-        compressedSize: compressedFile.size,
-        ratio: Number(((1 - compressedFile.size / file.size) * 100).toFixed(1)),
+        previewUrl: newPreviewUrl,
+        originalSize,
+        compressedSize,
+        ratio,
       }
 
       return result
@@ -82,7 +95,9 @@ export default function useImageCompress(
   }
 
   const reset = () => {
-    if (previewUrl) URL.revokeObjectURL(previewUrl)
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl)
+    }
     setPreviewUrl(null)
     setError(null)
   }


### PR DESCRIPTION
## 📌 이슈 넘버
> #85 

## 📄 작업 페이지 및 내용 요약
> 압축 훅 개선작업

## 📝 작업 내용
기존 압축후 이미지 품질이 안좋다는 의견이 있어 압축율을 낮추었습니다.
혹시 빈파일이거나 0이 들어올경우 방어하기위해 예외처리 추가하였습니다.

품질 개선은 아래와 같이 변경하였습니다.
```tsx
const { compress } = useImageCompress('post')
```
게시글용
1.5mb 압축에 85% 퀄리티 -> 3mb 압축에 90% 퀄리티로 변경
해상도 1920 유지
```tsx
const { compress } = useImageCompress('profile')
```
프로필용
0.5mb 압축에 85% 퀄리티 -> 1mb 압축에 90% 퀄리티로 변경
letina 화면에서 깨지는 현상을 줄이기 위해 해상도 512-> 1024 재조정 하였습니다.

