### PR TITLE
Feat(#61): virtuoso  increaseViewportBy 옵션 추가

### DIFF
--- a/src/components/comment/List/CommentList/index.tsx
+++ b/src/components/comment/List/CommentList/index.tsx
@@ -60,6 +60,7 @@ export default function CommentList({
     <Virtuoso
       useWindowScroll
       data={comments}
+      increaseViewportBy={{ top: 200, bottom: 200 }}
       endReached={handleEndReached}
       itemContent={(index, comment) => (
         <div className="pb-6">


### PR DESCRIPTION
## 📌 이슈 넘버
#61 

## 📄 작업 페이지 및 내용 요약
댓글이 렌더링 되지 않는 현상을 해결하기 위해  increaseViewportBy 옵션을 추가 하였습니다.

## 📝 작업 내용
react-virtuoso 옵션 최적화: increaseViewportBy 속성을 추가하여 뷰포트(화면) 상하단에 렌더링 버퍼 영역을 확보했습니다.
