### PR TITLE
Fix(#115): 게시글 최대인원 제한 및 비로그인 사용자 처리

### DIFF
--- a/src/components/post/Detail/ImageModal/index.tsx
+++ b/src/components/post/Detail/ImageModal/index.tsx
@@ -61,35 +61,27 @@ export default function ImageModal({
       </button>
       {/* 이미지 */}
       <div
-        className="max-w-7xl w-full relative overflow-hidden"
+        className="relative w-[90vw] h-[70vh]"
         onClick={(e) => e.stopPropagation()}
       >
-        <div
-          className="flex transition-transform duration-200 ease-in-out"
-          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-        >
-          {images.map((img, idx) => (
-            <div
-              key={img}
-              className="min-w-full h-[80vh] flex items-center justify-center relative"
-            >
-              {!loading.has(idx) && (
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="w-12 h-12 border-4 border-white/30 border-t-white rounded-full animate-spin" />
-                </div>
-              )}
-              <Image
-                src={img.startsWith('/') ? img : getImageUrl(img)}
-                alt="이미지 확대"
-                width={1200}
-                height={800}
-                className="object-contain max-w-full max-h-full rounded-3xl"
-                priority={idx === 0}
-                onLoad={() => ImageLoad(idx)}
-              />
-            </div>
-          ))}
-        </div>
+        {!loading.has(currentIndex) && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="w-12 h-12 border-4 border-white/30 border-t-white rounded-full animate-spin" />
+          </div>
+        )}
+        <Image
+          key={images[currentIndex]}
+          src={
+            images[currentIndex].startsWith('/')
+              ? images[currentIndex]
+              : getImageUrl(images[currentIndex])
+          }
+          alt={`이미지 ${currentIndex + 1}`}
+          fill
+          className="object-contain"
+          priority
+          onLoad={() => ImageLoad(currentIndex)}
+        />
         {/* 버튼 */}
         {images.length > 1 && (
           <>

--- a/src/components/post/Detail/ImageModal/index.tsx
+++ b/src/components/post/Detail/ImageModal/index.tsx
@@ -60,58 +60,57 @@ export default function ImageModal({
         <IconX className="size-8" />
       </button>
       {/* 이미지 */}
-      <div
-        className="relative max-w-[90vw] max-h-[70vh] overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="relative inline-block">
         {!loading.has(currentIndex) && (
-          <div className="absolute inset-0 flex items-center justify-center z-10">
+          <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
             <div className="w-12 h-12 border-4 border-white/30 border-t-white rounded-full animate-spin" />
           </div>
         )}
-        <div
-          className="flex transition-transform duration-300 ease-in-out"
-          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
-        >
-          {images.map((img, idx) => (
-            <div
-              key={img}
-              className="shrink-0 w-full flex items-center justify-center"
-            >
-              <Image
-                src={img.startsWith('/') ? img : getImageUrl(img)}
-                alt={`이미지 ${idx + 1}`}
-                width={1200}
-                height={800}
-                className="object-contain max-w-[90vw] max-h-[70vh] w-auto h-auto"
-                priority={idx === 0}
-                onLoad={() => ImageLoad(idx)}
-              />
-            </div>
-          ))}
-        </div>
+        <Image
+          src={
+            images[currentIndex].startsWith('/')
+              ? images[currentIndex]
+              : getImageUrl(images[currentIndex])
+          }
+          alt={`이미지 ${currentIndex + 1}`}
+          width={1200}
+          height={800}
+          className="object-contain max-w-[90vw] max-h-[70vh] w-auto h-auto"
+          priority
+          onLoad={() => ImageLoad(currentIndex)}
+          onClick={(e) => e.stopPropagation()}
+        />
         {/* 버튼 */}
         {images.length > 1 && (
           <>
             <button
-              onClick={goToPrevious}
-              className="absolute left-4 top-1/2 -translate-y-1/2 text-white hover:text-gray-300 transition-colors z-10 bg-black/30 rounded-full p-2 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation()
+                goToPrevious()
+              }}
+              className="absolute left-8 top-1/2 -translate-y-1/2 text-white hover:text-gray-300 transition-colors z-10 bg-black/30 rounded-full p-2 cursor-pointer"
               aria-label="이전 이미지"
             >
               <IconChevronLeft className="size-8" />
             </button>
             <button
-              onClick={goToNext}
-              className="absolute right-4 top-1/2 -translate-y-1/2 text-white hover:text-gray-300 transition-colors z-10 bg-black/30 rounded-full p-2 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation()
+                goToNext()
+              }}
+              className="absolute right-8 top-1/2 -translate-y-1/2 text-white hover:text-gray-300 transition-colors z-10 bg-black/30 rounded-full p-2 cursor-pointer"
               aria-label="다음 이미지"
             >
               <IconChevronRight className="size-8" />
             </button>
-            <div className="absolute bottom-12 left-1/2 -translate-x-1/2 flex gap-2 ">
+            <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex gap-2 ">
               {images.map((_, index) => (
                 <button
                   key={index}
-                  onClick={() => setCurrentIndex(index)}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setCurrentIndex(index)
+                  }}
                   className={cn(
                     'w-2 h-2 rounded-full transition-colors',
                     currentIndex === index ? 'bg-white' : 'bg-white/50',

--- a/src/components/post/Detail/ImageModal/index.tsx
+++ b/src/components/post/Detail/ImageModal/index.tsx
@@ -61,27 +61,35 @@ export default function ImageModal({
       </button>
       {/* 이미지 */}
       <div
-        className="relative w-[90vw] h-[70vh]"
+        className="relative max-w-[90vw] max-h-[70vh] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {!loading.has(currentIndex) && (
-          <div className="absolute inset-0 flex items-center justify-center">
+          <div className="absolute inset-0 flex items-center justify-center z-10">
             <div className="w-12 h-12 border-4 border-white/30 border-t-white rounded-full animate-spin" />
           </div>
         )}
-        <Image
-          key={images[currentIndex]}
-          src={
-            images[currentIndex].startsWith('/')
-              ? images[currentIndex]
-              : getImageUrl(images[currentIndex])
-          }
-          alt={`이미지 ${currentIndex + 1}`}
-          fill
-          className="object-contain"
-          priority
-          onLoad={() => ImageLoad(currentIndex)}
-        />
+        <div
+          className="flex transition-transform duration-300 ease-in-out"
+          style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+        >
+          {images.map((img, idx) => (
+            <div
+              key={img}
+              className="shrink-0 w-full flex items-center justify-center"
+            >
+              <Image
+                src={img.startsWith('/') ? img : getImageUrl(img)}
+                alt={`이미지 ${idx + 1}`}
+                width={1200}
+                height={800}
+                className="object-contain max-w-[90vw] max-h-[70vh] w-auto h-auto"
+                priority={idx === 0}
+                onLoad={() => ImageLoad(idx)}
+              />
+            </div>
+          ))}
+        </div>
         {/* 버튼 */}
         {images.length > 1 && (
           <>

--- a/src/components/post/Detail/PostImages/index.tsx
+++ b/src/components/post/Detail/PostImages/index.tsx
@@ -52,11 +52,11 @@ export default function PostImages({ images, onClick }: ImagesProps) {
   return (
     <div className="mb-6 relative group ">
       <div
-        className="relative w-full  rounded-3xl overflow-hidden pointer-events-none md:pointer-events-auto"
+        className="relative w-full  rounded-3xl overflow-hidden pointer-events-none md:pointer-events-auto cursor-pointer"
         onClick={() => onClick(currentIndex)}
       >
         <div
-          className="flex transition-transform duration-200 ease-in-out"
+          className="flex transition-transform duration-200 ease-in-out text-red-500"
           style={{ transform: `translateX(-${currentIndex * 100}%)` }}
         >
           {images.map((img, idx) => (
@@ -66,19 +66,26 @@ export default function PostImages({ images, onClick }: ImagesProps) {
           ))}
         </div>
       </div>
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex ">
         {images.map((_, index) => (
           <button
             key={index}
-            onClick={() => goToSlide(index)}
-            className={cn(
-              'w-2 h-2 rounded-full transition-all cursor-pointer',
-              currentIndex === index
-                ? 'bg-white w-2'
-                : 'bg-white/50 hover:bg-white/75',
-            )}
+            onClick={(e) => {
+              e.stopPropagation()
+              goToSlide(index)
+            }}
+            className="p-2 cursor-pointer"
             aria-label={`${index + 1}번째 이미지로 이동`}
-          />
+          >
+            <div
+              className={cn(
+                'w-2 h-2 rounded-full transition-all',
+                currentIndex === index
+                  ? 'bg-white'
+                  : 'bg-white/50 hover:bg-white/75',
+              )}
+            />
+          </button>
         ))}
       </div>
     </div>

--- a/src/components/post/Detail/PostImages/index.tsx
+++ b/src/components/post/Detail/PostImages/index.tsx
@@ -56,7 +56,7 @@ export default function PostImages({ images, onClick }: ImagesProps) {
         onClick={() => onClick(currentIndex)}
       >
         <div
-          className="flex transition-transform duration-200 ease-in-out text-red-500"
+          className="flex transition-transform duration-200 ease-in-out"
           style={{ transform: `translateX(-${currentIndex * 100}%)` }}
         >
           {images.map((img, idx) => (

--- a/src/components/post/Detail/index.test.tsx
+++ b/src/components/post/Detail/index.test.tsx
@@ -135,6 +135,7 @@ jest.mock('@/hooks/posts', () => ({
   useBookmarkToggle: jest.fn(),
   useApply: jest.fn(),
   usePostManage: jest.fn(),
+  useCompanionId: jest.fn(),
 }))
 
 jest.mock('@/components/comment', () => ({
@@ -183,7 +184,7 @@ beforeEach(() => {
     data: { pages: [] },
   })
 
-  const { useBookmarkToggle, useApply, usePostManage } =
+  const { useBookmarkToggle, useApply, usePostManage, useCompanionId } =
     jest.requireMock('@/hooks/posts')
   useBookmarkToggle.mockReturnValue({
     toggleBookmark: jest.fn(),
@@ -199,6 +200,7 @@ beforeEach(() => {
     handleDelete: jest.fn(),
     isDeleting: false,
   })
+  useCompanionId.mockReturnValue(undefined)
 })
 
 const { usePostDetail } = jest.requireMock('@/api/posts')
@@ -432,26 +434,17 @@ describe('게시글 권한 테스트', () => {
     })
     test('신청 취소 버튼을 누르면 동행 신청이 취소된다', async () => {
       const mockHandleCancel = jest.fn()
-      const { useCancelCompanion, useInfiniteGetSentCompanions } =
-        jest.requireMock('@/api/companions')
+      const { useCancelCompanion } = jest.requireMock('@/api/companions')
+      const { useCompanionId } = jest.requireMock('@/hooks/posts')
+
       useCancelCompanion.mockReturnValue({
         mutate: mockHandleCancel,
         isPending: false,
       })
-      useInfiniteGetSentCompanions.mockReturnValue({
-        data: {
-          pages: [
-            {
-              content: [
-                {
-                  postResponse: { id: '1' },
-                  myGuestCompanionResponse: { companionId: '123' },
-                },
-              ],
-            },
-          ],
-        },
-      })
+
+      // useCompanionId가 '123'을 반환하도록 mock 설정
+      useCompanionId.mockReturnValue('123')
+
       usePostDetail.mockReturnValue({
         data: {
           success: true,

--- a/src/components/post/Detail/index.tsx
+++ b/src/components/post/Detail/index.tsx
@@ -1,15 +1,12 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
-import {
-  useCancelCompanion,
-  useInfiniteGetSentCompanions,
-} from '@/api/companions'
+import { useCancelCompanion } from '@/api/companions'
 import { usePostDetail } from '@/api/posts'
 import Comment from '@/components/comment'
 import { toast } from '@/components/common'
-import { useApply } from '@/hooks/posts'
+import { useApply, useCompanionId } from '@/hooks/posts'
 import { useModalActions } from '@/stores'
 import { SentCompanionContent } from '@/types/companions'
 
@@ -31,28 +28,13 @@ export default function PostDetail({
   data?: SentCompanionContent
 }) {
   const { data: response, isLoading, refetch } = usePostDetail({ postId })
-  const { data: sentCompanionsData } = useInfiniteGetSentCompanions('PENDING')
   const [imageModalState, setImageModalState] = useState<{
     isOpen: boolean
     initialIndex: number
   }>({ isOpen: false, initialIndex: 0 })
 
-  const companionId = useMemo(() => {
-    if (data?.myGuestCompanionResponse?.companionId) {
-      return data.myGuestCompanionResponse.companionId
-    }
-    if (!sentCompanionsData?.pages) return undefined
-    for (const page of sentCompanionsData.pages) {
-      const found = page.content.find(
-        (item) => String(item.postResponse.id) === postId,
-      )
-      if (found) {
-        return found.myGuestCompanionResponse.companionId
-      }
-    }
-
-    return undefined
-  }, [data, sentCompanionsData, postId])
+  // 커스텀 훅으로 companionId 조회 (O(1) 성능 최적화)
+  const companionId = useCompanionId(postId, data, true)
   const { handleApplyCompanion } = useApply(postId)
   const { openModal, closeModal } = useModalActions()
   const { mutate, isPending } = useCancelCompanion()

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -4,13 +4,15 @@ import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
 
-import {
-  useCancelCompanion,
-  useInfiniteGetSentCompanions,
-} from '@/api/companions'
+import { useCancelCompanion } from '@/api/companions'
 import { toast } from '@/components/common'
 import { OtherProfile } from '@/components/member'
-import { useApply, useBookmarkToggle, usePostManage } from '@/hooks/posts'
+import {
+  useApply,
+  useBookmarkToggle,
+  useCompanionId,
+  usePostManage,
+} from '@/hooks/posts'
 import { isDatePassed } from '@/lib/common/time-format'
 import { useModalActions } from '@/stores'
 import { SentCompanionContent } from '@/types/companions'
@@ -40,26 +42,9 @@ export default function PostCard({
   )
   const { handleEdit, handleDelete } = usePostManage(post.postId)
   const { data: session } = useSession()
-  const { data: sentCompanionsData } = useInfiniteGetSentCompanions(
-    'PENDING',
-    !!session?.user,
-  )
 
-  const companionId = useMemo(() => {
-    if (data?.myGuestCompanionResponse?.companionId) {
-      return data.myGuestCompanionResponse.companionId
-    }
-    if (!sentCompanionsData?.pages) return undefined
-    for (const page of sentCompanionsData.pages) {
-      const found = page.content.find(
-        (item) => String(item.postResponse.id) === String(post.postId),
-      )
-      if (found) {
-        return found.myGuestCompanionResponse.companionId
-      }
-    }
-    return undefined
-  }, [data, sentCompanionsData, post.postId])
+  // 커스텀 훅으로 companionId 조회 (O(1) 성능 최적화)
+  const companionId = useCompanionId(post.postId, data, !!session?.user)
 
   const handleCancelCompanion = async (companionId: string) => {
     mutate(companionId, {

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -59,6 +59,7 @@ export default function PostCard({
     }
     return undefined
   }, [data, sentCompanionsData, post.postId])
+
   const handleCancelCompanion = async (companionId: string) => {
     mutate(companionId, {
       onSuccess: () => {
@@ -70,6 +71,11 @@ export default function PostCard({
     })
   }
   const handleOpenApplyModal = () => {
+    if (!session?.user) {
+      toast.error('로그인이 필요한 서비스입니다.')
+      router.push('/auth/signin')
+      return
+    }
     openModal(
       <ApplyModal
         onClose={closeModal}
@@ -103,7 +109,7 @@ export default function PostCard({
           nickname={post.nickname}
           tags={post.tags}
           isOwner={post.isOwner}
-          currentMembers={post.currentMembers}
+          currentMembers={post.currentMembers + (post.isApplied ? 1 : 0)}
           nation={post.nation}
           period={post.period}
           conditions={post.conditions}

--- a/src/components/post/List/PostCard/index.tsx
+++ b/src/components/post/List/PostCard/index.tsx
@@ -11,6 +11,7 @@ import {
 import { toast } from '@/components/common'
 import { OtherProfile } from '@/components/member'
 import { useApply, useBookmarkToggle, usePostManage } from '@/hooks/posts'
+import { isDatePassed } from '@/lib/common/time-format'
 import { useModalActions } from '@/stores'
 import { SentCompanionContent } from '@/types/companions'
 import { PostListItem } from '@/types/posts'
@@ -92,14 +93,19 @@ export default function PostCard({
   const handleWriterClick = () => {
     openModal(<OtherProfile memberId={String(post.writer.memberId)} />)
   }
-
+  const actualRecruitStatus = useMemo(() => {
+    if (post.recruitStatus === 'COMPLETED' || post.recruitStatus === 'FINISH') {
+      return post.recruitStatus
+    }
+    return isDatePassed(post.period.endDate) ? 'COMPLETED' : post.recruitStatus
+  }, [post.recruitStatus, post.period.endDate])
   return (
     <div className="bg-white rounded-2xl md:p-6 shadow-sm hover:shadow-md transition-shadow">
       <div className="flex md:gap-6 md:flex-row flex-col gap-0">
         <PostCardImage
           thumbnail={post.thumbnail}
           title={post.title}
-          recruitStatus={post.recruitStatus}
+          recruitStatus={actualRecruitStatus}
           priority={priority}
         />
 
@@ -122,7 +128,7 @@ export default function PostCard({
         <PostCardActions
           isOwner={post.isOwner}
           isBookmarked={post.isBookmarked}
-          recruitStatus={post.recruitStatus}
+          recruitStatus={actualRecruitStatus}
           isApplied={post.isApplied}
           onBookmarkClick={handleToggleBookmark}
           onEditClick={handleEdit}

--- a/src/hooks/posts/index.ts
+++ b/src/hooks/posts/index.ts
@@ -1,4 +1,5 @@
 export * from './useApply'
 export * from './useBookmarkToggle'
+export * from './useCompanionId'
 export * from './useInfinitePosts'
 export * from './usePostManage'

--- a/src/hooks/posts/useBookmarkToggle.ts
+++ b/src/hooks/posts/useBookmarkToggle.ts
@@ -1,10 +1,20 @@
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+
 import { useAddBookmark, useRemoveBookmark } from '@/api/posts'
+import { toast } from '@/components/common'
 
 export const useBookmarkToggle = (postId: string, isBookmarked: boolean) => {
   const addBookmark = useAddBookmark()
   const removeBookmark = useRemoveBookmark()
-
+  const session = useSession()
+  const router = useRouter()
   const toggleBookmark = async (e?: React.MouseEvent) => {
+    if (!session?.data?.user) {
+      toast.error('로그인이 필요한 서비스입니다.')
+      router.push('/auth/signin')
+      return
+    }
     e?.stopPropagation()
 
     if (isBookmarked) {

--- a/src/hooks/posts/useCompanionId.ts
+++ b/src/hooks/posts/useCompanionId.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+
+import { useInfiniteGetSentCompanions } from '@/api/companions'
+import { SentCompanionContent } from '@/types/companions'
+
+export function useCompanionId(
+  postId: string,
+  propsData?: SentCompanionContent,
+  enabled = true,
+) {
+  const { data: sentCompanionsData } = useInfiniteGetSentCompanions(
+    'PENDING',
+    enabled,
+  )
+
+  const companionId = useMemo(() => {
+    if (propsData?.myGuestCompanionResponse?.companionId) {
+      return propsData.myGuestCompanionResponse.companionId
+    }
+
+    if (!sentCompanionsData?.pages) return undefined
+
+    const companionMap = new Map<string, string>()
+
+    for (const page of sentCompanionsData.pages) {
+      for (const item of page.content) {
+        const itemPostId = String(item.postResponse.id)
+        companionMap.set(itemPostId, item.myGuestCompanionResponse.companionId)
+      }
+    }
+
+    return companionMap.get(String(postId))
+  }, [propsData, sentCompanionsData, postId])
+
+  return companionId
+}

--- a/src/lib/common/time-format.ts
+++ b/src/lib/common/time-format.ts
@@ -124,3 +124,18 @@ export const formatKstDate = (
 
   return d.tz('Asia/Seoul').format(format)
 }
+
+/**
+ * 주어진 날짜가 현재 날짜보다 이전인지 확인
+ * @param endDate - 확인할 종료 날짜 (YYYY-MM-DD 형식)
+ * @returns 날짜가 지났으면 true, 아니면 false
+ */
+export const isDatePassed = (endDate?: string | null): boolean => {
+  if (!endDate) return false
+
+  const end = dayjs(endDate)
+  if (!end.isValid()) return false
+
+  // 현재 날짜의 시작 시간 (00:00:00)과 비교
+  return end.isBefore(dayjs().startOf('day'))
+}

--- a/src/types/posts/schema.ts
+++ b/src/types/posts/schema.ts
@@ -13,7 +13,8 @@ export const postSchema = z
 
     maxMembers: z
       .number('숫자만 입력 가능합니다')
-      .min(1, '모집 정원을 1명 이상 입력해주세요'),
+      .min(1, '1명 이상 입력해주세요')
+      .max(10, '최대 10명까지 가능합니다'),
 
     ageType: z.nativeEnum(AgeType).refine((v) => v !== undefined, {
       message: '나이를 선택해주세요',


### PR DESCRIPTION
## 📌 이슈 넘버
> close #115 

## 📄 작업 페이지 및 내용 요약
> 인원 입력에 대한 유효성 검증을 추가하고, 이미지 및 버튼 UI를 실제 사용 흐름에 맞게 수정했습니다.

## 📝 작업 내용
> zod를 사용하여 최대 인원 입력값에 대한 유효성 검증을 추가하고 허용 범위를 벗어나는 값이 제출되지 않도록 제한했습니다.

> 이미지 영역이 실제 이미지 크기보다 과도하게 커 보이던 문제를 개선하였고, 확대해서 확인하는 용도에 맞게 rounded-3xl 스타일을 제거했습니다.

> 클릭 영역이 좁은 버튼에 패딩을 추가하여 터치 영역을 확장하고 편의성을 개선했습니다.

## 📸 스크린샷
<img width="873" height="775" alt="image" src="https://github.com/user-attachments/assets/842bbc1e-ead9-431c-8a70-5578c48ae4f2" />
zod를 사용하여 최대 인원에 제한을 뒀습니다

<img width="765" height="624" alt="image" src="https://github.com/user-attachments/assets/bf318ff6-8649-4adc-9469-244d14386e0e" />
이미지 요소 영역이 이미지보다 크지않고 이미지를 제대로 보려고 확대한다 생각해서 rounded-3xl은 제거했습니다.

<img width="1163" height="412" alt="image" src="https://github.com/user-attachments/assets/c85f4a58-6e70-498b-8d19-2b55b022753d" />
버튼에 패딩을 추가해 영역을 확장 시켰습니다


