### PR TITLE
Fix: 보고된 로그인 직후 채팅방 페이지 접근 시 로그인페이지로 리다이렉트 문제 해결

### DIFF
--- a/src/components/auth/AdditionalForm/BirthFieldset/index.tsx
+++ b/src/components/auth/AdditionalForm/BirthFieldset/index.tsx
@@ -17,7 +17,7 @@ export default function BirthFieldset(props: Props) {
 
   return (
     <AnimateFieldset {...props}>
-      <FormDatePicker label="생년월일 선택" name="birth" required />
+      <FormDatePicker label="생년월일" name="birth" required />
       <p className="h-6 flex text-xs text-red items-center gap-1 px-4">
         {errors.birth && <CircleAlert className="size-4" />}
         <span>{errors.birth?.message}</span>

--- a/src/components/auth/AdditionalForm/EmailFieldset/index.tsx
+++ b/src/components/auth/AdditionalForm/EmailFieldset/index.tsx
@@ -9,7 +9,7 @@ type Props = ComponentProps<typeof AnimateFieldset>
 export default function EmailFieldset(props: Props) {
   return (
     <AnimateFieldset {...props} disabled>
-      <legend className="sr-only">비밀번호 입력 및 확인</legend>
+      <legend className="sr-only">이메일 입력</legend>
       <FormInput
         label="이메일"
         type="email"

--- a/src/components/auth/SigninForm/index.tsx
+++ b/src/components/auth/SigninForm/index.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Loader } from 'lucide-react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { useSigninEmail } from '@/api/auth'
@@ -14,7 +14,6 @@ import { SigninFormValues, signinSchema } from '@/types/auth'
 import { AnimateFieldset } from '../form'
 
 export default function SigninForm() {
-  const router = useRouter()
   const searchParams = useSearchParams()
   const callbackUrl = searchParams.get('callbackUrl') || '/'
 
@@ -36,7 +35,7 @@ export default function SigninForm() {
       onSuccess: () => {
         toast.success('로그인 되었습니다')
 
-        router.push(callbackUrl)
+        window.location.href = callbackUrl
       },
       onError: () => {
         toast.error('이메일 또는 비밀번호를 확인해주세요')

--- a/src/components/auth/SigninForm/index.tsx
+++ b/src/components/auth/SigninForm/index.tsx
@@ -15,7 +15,11 @@ import { AnimateFieldset } from '../form'
 
 export default function SigninForm() {
   const searchParams = useSearchParams()
-  const callbackUrl = searchParams.get('callbackUrl') || '/'
+  const unsafeCallbackUrl = searchParams.get('callbackUrl')
+  const callbackUrl =
+    unsafeCallbackUrl && unsafeCallbackUrl.startsWith('/')
+      ? unsafeCallbackUrl
+      : '/'
 
   const { mutate, isPending } = useSigninEmail()
   const methods = useForm<SigninFormValues>({


### PR DESCRIPTION
- Next 서버에 브라우저의 쿠키가 전달되기전 api 호출로 인한 로그인 페이지 리다이렉션 현상 수정
( 권장 되는 방향은 아니나, 급한 정상화를 위해 로그인 성공 후 window.location.href로 페이지 이동 시켰습니다. )