### PR TITLE
Test(#137): comment 도메인 Jest / Testing Library 테스트 코드 작성

### DIFF
--- a/src/features/comment/components/CommentContainer.test.tsx
+++ b/src/features/comment/components/CommentContainer.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useParams } from 'next/navigation'
+
+import CommentContainer from './CommentContainer'
+
+jest.mock('@/assets/svgr/reload.svg', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+const mockMutateAsync = jest.fn().mockResolvedValue(undefined)
+const mockRefetch = jest.fn()
+const mockFetchNextPage = jest.fn()
+
+jest.mock('@/features/comment/api', () => ({
+  useCommentMutations: jest.fn(() => ({
+    createCommentMutation: {
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    },
+  })),
+  useComments: jest.fn(() => ({
+    comments: [],
+    isLoading: false,
+    fetchNextPage: mockFetchNextPage,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isError: false,
+    refetch: mockRefetch,
+  })),
+}))
+
+jest.mock('@/features/comment/components/List/CommentList/CommentList', () => ({
+  __esModule: true,
+  default: ({ comments }: { comments: { commentId: number }[] }) => (
+    <div data-testid="comment-list">{comments.length}개 댓글</div>
+  ),
+}))
+
+const { useComments } = jest.requireMock('@/features/comment/api')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(useParams as jest.Mock).mockReturnValue({ postId: '1' })
+  useComments.mockReturnValue({
+    comments: [],
+    isLoading: false,
+    fetchNextPage: mockFetchNextPage,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isError: false,
+    refetch: mockRefetch,
+  })
+  mockMutateAsync.mockResolvedValue(undefined)
+})
+
+describe('렌더링', () => {
+  it('commentCount를 표시한다', () => {
+    render(<CommentContainer commentCount={5} />)
+
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('댓글 작성 폼이 렌더링된다', () => {
+    render(<CommentContainer commentCount={0} />)
+
+    expect(
+      screen.getByPlaceholderText('댓글을 입력해주세요'),
+    ).toBeInTheDocument()
+  })
+
+  it('CommentList가 렌더링된다', () => {
+    render(<CommentContainer commentCount={0} />)
+
+    expect(screen.getByTestId('comment-list')).toBeInTheDocument()
+  })
+
+  it('isError=true일 때 에러 메시지와 재시도 버튼이 표시된다', () => {
+    useComments.mockReturnValue({
+      comments: [],
+      isLoading: false,
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isError: true,
+      refetch: mockRefetch,
+    })
+
+    render(<CommentContainer commentCount={0} />)
+
+    expect(
+      screen.getByText('댓글을 불러오는데 실패했습니다.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /다시 시도/ }),
+    ).toBeInTheDocument()
+  })
+
+  it('isError=true일 때 CommentList가 렌더링되지 않는다', () => {
+    useComments.mockReturnValue({
+      comments: [],
+      isLoading: false,
+      fetchNextPage: mockFetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isError: true,
+      refetch: mockRefetch,
+    })
+
+    render(<CommentContainer commentCount={0} />)
+
+    expect(screen.queryByTestId('comment-list')).not.toBeInTheDocument()
+  })
+})
+
+describe('댓글 작성', () => {
+  it('폼 제출 시 createCommentMutation.mutateAsync가 postId와 content로 호출된다', async () => {
+    const user = userEvent.setup()
+    render(<CommentContainer commentCount={0} />)
+
+    await user.type(
+      screen.getByPlaceholderText('댓글을 입력해주세요'),
+      '새 댓글입니다',
+    )
+    await user.click(screen.getByRole('button', { name: '댓글 작성' }))
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        postId: 1,
+        content: '새 댓글입니다',
+      }),
+    )
+  })
+
+  it('postId가 string으로 와도 number로 변환해 호출한다', async () => {
+    const user = userEvent.setup()
+    ;(useParams as jest.Mock).mockReturnValue({ postId: '42' })
+    render(<CommentContainer commentCount={0} />)
+
+    await user.type(screen.getByPlaceholderText('댓글을 입력해주세요'), '댓글')
+    await user.click(screen.getByRole('button', { name: '댓글 작성' }))
+
+    await waitFor(() =>
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ postId: 42 }),
+      ),
+    )
+  })
+})

--- a/src/features/comment/components/CommentForm/CommentForm.test.tsx
+++ b/src/features/comment/components/CommentForm/CommentForm.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import CommentForm from './CommentForm'
+
+jest.mock('@/lib/common/image', () => ({
+  getImageUrl: jest.fn(() => 'https://test.com/profile.jpg'),
+}))
+
+jest.mock('@/components/common', () => ({
+  ...jest.requireActual('@/components/common'),
+  toast: { error: jest.fn(), success: jest.fn() },
+}))
+
+const { toast } = jest.requireMock('@/components/common')
+
+const defaultProps = {
+  mode: 'create' as const,
+  userImage: null,
+  isSubmitting: false,
+  onSubmit: jest.fn().mockResolvedValue(undefined),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  defaultProps.onSubmit = jest.fn().mockResolvedValue(undefined)
+})
+
+describe('mode별 렌더링', () => {
+  it('mode=create: placeholder와 버튼 텍스트가 올바르게 렌더링된다', () => {
+    render(<CommentForm {...defaultProps} mode="create" />)
+
+    expect(
+      screen.getByPlaceholderText('댓글을 입력해주세요'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: '댓글 작성' }),
+    ).toBeInTheDocument()
+  })
+
+  it('mode=reply: 취소 버튼이 노출된다', () => {
+    render(<CommentForm {...defaultProps} mode="reply" />)
+
+    expect(screen.getByRole('button', { name: '취소' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: '답글 작성' }),
+    ).toBeInTheDocument()
+  })
+
+  it('mode=create: 취소 버튼이 없다', () => {
+    render(<CommentForm {...defaultProps} mode="create" />)
+
+    expect(
+      screen.queryByRole('button', { name: '취소' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('mode=edit: initialValue가 textarea에 채워진다', () => {
+    render(
+      <CommentForm
+        {...defaultProps}
+        mode="edit"
+        initialValue="기존 댓글 내용"
+      />,
+    )
+
+    expect(screen.getByDisplayValue('기존 댓글 내용')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: '수정 완료' }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('제출 버튼 활성화 / 비활성화', () => {
+  it('빈 텍스트일 때 제출 버튼이 disabled다', () => {
+    render(<CommentForm {...defaultProps} />)
+
+    expect(screen.getByRole('button', { name: '댓글 작성' })).toBeDisabled()
+  })
+
+  it('텍스트 입력 후 제출 버튼이 활성화된다', async () => {
+    const user = userEvent.setup()
+    render(<CommentForm {...defaultProps} />)
+
+    await user.type(
+      screen.getByPlaceholderText('댓글을 입력해주세요'),
+      '안녕하세요',
+    )
+
+    expect(screen.getByRole('button', { name: '댓글 작성' })).toBeEnabled()
+  })
+
+  it('공백만 입력하면 제출 버튼이 disabled다', async () => {
+    const user = userEvent.setup()
+    render(<CommentForm {...defaultProps} />)
+
+    await user.type(screen.getByPlaceholderText('댓글을 입력해주세요'), '   ')
+
+    expect(screen.getByRole('button', { name: '댓글 작성' })).toBeDisabled()
+  })
+
+  it('isSubmitting=true일 때 textarea와 버튼이 모두 disabled다', () => {
+    render(
+      <CommentForm {...defaultProps} isSubmitting={true} initialValue="내용" />,
+    )
+
+    expect(screen.getByRole('textbox')).toBeDisabled()
+    expect(screen.getByRole('button', { name: '댓글 작성' })).toBeDisabled()
+  })
+})
+
+describe('제출 동작', () => {
+  it('onSubmit이 trim된 텍스트로 호출된다', async () => {
+    const user = userEvent.setup()
+    render(<CommentForm {...defaultProps} />)
+
+    await user.type(
+      screen.getByPlaceholderText('댓글을 입력해주세요'),
+      '  안녕하세요  ',
+    )
+    await user.click(screen.getByRole('button', { name: '댓글 작성' }))
+
+    expect(defaultProps.onSubmit).toHaveBeenCalledWith('안녕하세요')
+  })
+
+  it('제출 성공 후 textarea가 초기화된다', async () => {
+    const user = userEvent.setup()
+    render(<CommentForm {...defaultProps} />)
+
+    const textarea = screen.getByPlaceholderText('댓글을 입력해주세요')
+    await user.type(textarea, '안녕하세요')
+    await user.click(screen.getByRole('button', { name: '댓글 작성' }))
+
+    await waitFor(() => expect(textarea).toHaveValue(''))
+  })
+
+  it('제출 성공 후 onDeActivate가 호출된다', async () => {
+    const user = userEvent.setup()
+    const onDeActivate = jest.fn()
+    render(
+      <CommentForm
+        {...defaultProps}
+        mode="reply"
+        onDeActivate={onDeActivate}
+      />,
+    )
+
+    await user.type(
+      screen.getByPlaceholderText('답글을 입력해주세요'),
+      '답글입니다',
+    )
+    await user.click(screen.getByRole('button', { name: '답글 작성' }))
+
+    await waitFor(() => expect(onDeActivate).toHaveBeenCalledTimes(1))
+  })
+
+  it('제출 실패 시 toast.error가 호출된다', async () => {
+    const user = userEvent.setup()
+    defaultProps.onSubmit.mockRejectedValueOnce(new Error('서버 에러'))
+    render(<CommentForm {...defaultProps} />)
+
+    await user.type(
+      screen.getByPlaceholderText('댓글을 입력해주세요'),
+      '안녕하세요',
+    )
+    await user.click(screen.getByRole('button', { name: '댓글 작성' }))
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        '작업을 완료하지 못했습니다. 다시 시도해주세요.',
+      ),
+    )
+  })
+
+  it('빠른 연속 클릭 시 onSubmit이 1번만 호출된다', async () => {
+    const user = userEvent.setup()
+    let resolveSubmit!: () => void
+    const slowOnSubmit = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve
+        }),
+    )
+    render(<CommentForm {...defaultProps} onSubmit={slowOnSubmit} />)
+
+    await user.type(
+      screen.getByPlaceholderText('댓글을 입력해주세요'),
+      '안녕하세요',
+    )
+
+    const submitBtn = screen.getByRole('button', { name: '댓글 작성' })
+    await user.click(submitBtn)
+    await user.click(submitBtn)
+    await user.click(submitBtn)
+
+    resolveSubmit()
+    await waitFor(() => expect(slowOnSubmit).toHaveBeenCalledTimes(1))
+  })
+})

--- a/src/features/comment/hooks/useCommentActions.test.ts
+++ b/src/features/comment/hooks/useCommentActions.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useCommentActions } from './useCommentActions'
+
+const mockMutate = jest.fn()
+const mockMutateAsync = jest.fn()
+
+jest.mock('../api', () => ({
+  useCommentMutations: jest.fn(() => ({
+    updateCommentMutation: {
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    },
+    removeCommentMutation: {
+      mutate: mockMutate,
+    },
+  })),
+}))
+
+const { useCommentMutations } = jest.requireMock('../api')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  useCommentMutations.mockReturnValue({
+    updateCommentMutation: { mutateAsync: mockMutateAsync, isPending: false },
+    removeCommentMutation: { mutate: mockMutate },
+  })
+})
+
+describe('handleDelete', () => {
+  it('removeCommentMutation.mutate를 commentId와 parentId로 호출한다', () => {
+    const { result } = renderHook(() => useCommentActions(1, 10, 5))
+
+    act(() => {
+      result.current.handleDelete()
+    })
+
+    expect(mockMutate).toHaveBeenCalledWith({ commentId: 1, parentId: 5 })
+  })
+
+  it('parentId 없으면 undefined로 전달된다', () => {
+    const { result } = renderHook(() => useCommentActions(1, 10))
+
+    act(() => {
+      result.current.handleDelete()
+    })
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      commentId: 1,
+      parentId: undefined,
+    })
+  })
+})
+
+describe('handleSave', () => {
+  it('updateCommentMutation.mutateAsync를 commentId와 content로 호출한다', async () => {
+    const { result } = renderHook(() => useCommentActions(1, 10))
+
+    await act(async () => {
+      await result.current.handleSave('수정된 댓글')
+    })
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      commentId: 1,
+      content: '수정된 댓글',
+    })
+  })
+})
+
+describe('isUpdating', () => {
+  it('updateCommentMutation.isPending이 false면 isUpdating도 false다', () => {
+    const { result } = renderHook(() => useCommentActions(1, 10))
+
+    expect(result.current.isUpdating).toBe(false)
+  })
+
+  it('updateCommentMutation.isPending이 true면 isUpdating도 true다', () => {
+    useCommentMutations.mockReturnValue({
+      updateCommentMutation: { mutateAsync: mockMutateAsync, isPending: true },
+      removeCommentMutation: { mutate: mockMutate },
+    })
+
+    const { result } = renderHook(() => useCommentActions(1, 10))
+
+    expect(result.current.isUpdating).toBe(true)
+  })
+})

--- a/src/features/comment/hooks/useReplyActions.test.ts
+++ b/src/features/comment/hooks/useReplyActions.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useReplyActions } from './useReplyActions'
+
+const mockMutate = jest.fn()
+const mockMutateAsync = jest.fn()
+
+jest.mock('../api', () => ({
+  useReplyMutations: jest.fn(() => ({
+    updateReplyMutation: {
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    },
+    removeReplyMutation: {
+      mutate: mockMutate,
+    },
+  })),
+}))
+
+const { useReplyMutations } = jest.requireMock('../api')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  useReplyMutations.mockReturnValue({
+    updateReplyMutation: { mutateAsync: mockMutateAsync, isPending: false },
+    removeReplyMutation: { mutate: mockMutate },
+  })
+})
+
+describe('handleDelete', () => {
+  it('removeReplyMutation.mutate를 commentId로 호출한다', () => {
+    const { result } = renderHook(() => useReplyActions(11, 10, 1))
+
+    act(() => {
+      result.current.handleDelete()
+    })
+
+    expect(mockMutate).toHaveBeenCalledWith({ commentId: 11 })
+  })
+
+  it('parentId는 mutate 인자에 포함되지 않는다', () => {
+    const { result } = renderHook(() => useReplyActions(11, 10, 1))
+
+    act(() => {
+      result.current.handleDelete()
+    })
+
+    expect(mockMutate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ parentId: expect.anything() }),
+    )
+  })
+})
+
+describe('handleSave', () => {
+  it('updateReplyMutation.mutateAsync를 commentId와 content로 호출한다', async () => {
+    const { result } = renderHook(() => useReplyActions(11, 10, 1))
+
+    await act(async () => {
+      await result.current.handleSave('수정된 답글')
+    })
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      commentId: 11,
+      content: '수정된 답글',
+    })
+  })
+})
+
+describe('isUpdating', () => {
+  it('updateReplyMutation.isPending이 false면 isUpdating도 false다', () => {
+    const { result } = renderHook(() => useReplyActions(11, 10, 1))
+
+    expect(result.current.isUpdating).toBe(false)
+  })
+
+  it('updateReplyMutation.isPending이 true면 isUpdating도 true다', () => {
+    useReplyMutations.mockReturnValue({
+      updateReplyMutation: { mutateAsync: mockMutateAsync, isPending: true },
+      removeReplyMutation: { mutate: mockMutate },
+    })
+
+    const { result } = renderHook(() => useReplyActions(11, 10, 1))
+
+    expect(result.current.isUpdating).toBe(true)
+  })
+})


### PR DESCRIPTION
## 📌 이슈 넘버
#137 

## 📝 작업 내용
**useCommentActions.test.ts**
- handleDelete 호출 시 `removeCommentMutation.mutate`가 `commentId`와 `parentId`를 포함한 인자로 호출되는지 검증
- `parentId` 미전달 시 `undefined`로 전달되는지 검증
- handleSave 호출 시 `updateCommentMutation.mutateAsync`가 `commentId`와 `content`로 호출되는지 검증
- `isUpdating`이 `updateCommentMutation.isPending` 값을 그대로 반영하는지 검증

**useReplyActions.test.ts**
- handleDelete 호출 시 `removeReplyMutation.mutate`가 `commentId`만 포함하고 `parentId`는 포함하지 않는지 검증
- handleSave 호출 시 `updateReplyMutation.mutateAsync`가 `commentId`와 `content`로 호출되는지 검증
- `isUpdating`이 `updateReplyMutation.isPending` 값을 그대로 반영하는지 검증

**CommentForm.test.tsx**
- `mode=create / reply / edit` 별 placeholder, 버튼 텍스트, 취소 버튼 노출 여부 렌더링 검증
- `mode=edit`일 때 `initialValue`가 textarea에 채워지는지 검증
- 빈 텍스트 및 공백만 입력 시 제출 버튼이 disabled 상태인지 검증
- 텍스트 입력 후 제출 버튼이 활성화되는지 검증
- `isSubmitting=true`일 때 textarea와 버튼이 모두 disabled인지 검증
- `onSubmit`이 trim된 텍스트로 호출되는지 검증
- 제출 성공 후 textarea 초기화 및 `onDeActivate` 호출 검증
- 제출 실패 시 `toast.error` 호출 검증
- 빠른 연속 클릭 시 `onSubmit`이 1번만 호출되는지 검증 (중복 제출 방지)

**CommentContainer.test.tsx**
- `commentCount` props가 화면에 표시되는지 검증
- 댓글 작성 폼과 CommentList가 렌더링되는지 검증
- `isError=true`일 때 에러 메시지와 재시도 버튼 표시, CommentList 미렌더링 검증
- 폼 제출 시 `createCommentMutation.mutateAsync`가 `postId`(number)와 `content`로 호출되는지 검증
- `postId`가 string으로 전달되어도 number로 변환되어 호출되는지 검증
